### PR TITLE
Add contributing guides

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+^\.github$
 ^LICENSE\.md$
 ^README\.Rmd$
 ^README-.*\.png$

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,25 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who 
+contribute through reporting issues, posting feature requests, updating documentation,
+submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or
+imagery, derogatory comments or personal attacks, trolling, public or private harassment,
+insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this 
+Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed 
+from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by 
+opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the Contributor Covenant 
+(http://contributor-covenant.org), version 1.0.0, available at 
+http://contributor-covenant.org/version/1/0/0/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to dccvalidator
+
+This outlines how to propose a change to dccvalidator.
+
+### Fixing typos
+
+Small typos or grammatical errors in documentation may be edited directly using
+the GitHub web interface, so long as the changes are made in the _source_ file.
+
+*  YES: you edit a roxygen comment in a `.R` file below `R/`.
+*  NO: you edit an `.Rd` file below `man/`.
+
+### Prerequisites
+
+Before you make a substantial pull request, you should always file an issue and
+make sure someone from the team agrees that it’s a problem. If you’ve found a
+bug, create an associated issue and illustrate the bug with a minimal 
+[reprex](https://www.tidyverse.org/help/#reprex).
+
+### Pull request process
+
+*  We recommend that you create a Git branch for each pull request (PR).  
+*  Look at the Travis build status before and after making changes. The `README`
+should contain badges for any continuous integration services used
+by the package.  
+*  New code should follow the tidyverse [style guide](http://style.tidyverse.org).
+You can use the [styler](https://CRAN.R-project.org/package=styler) package to
+apply these styles, but please don't restyle code that has nothing to do with 
+your PR.  
+*  We use [roxygen2](https://cran.r-project.org/package=roxygen2), with
+[Markdown syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/markdown.html), 
+for documentation.  
+*  We use [testthat](https://cran.r-project.org/package=testthat). Contributions
+with test cases included are easier to accept.  
+
+### Code of Conduct
+
+Please note that the dccvalidator project is released with a
+[Contributor Code of Conduct](CODE_OF_CONDUCT.md). By contributing to this
+project you agree to abide by its terms.
+
+

--- a/README.Rmd
+++ b/README.Rmd
@@ -53,3 +53,7 @@ dat <- data.frame(assay = "foo", b = 2)
 check_annotation_keys(dat)
 check_annotation_values(dat)
 ```
+
+Please note that the dccvalidator project is released with a [Contributor Code
+of Conduct](.github/CODE_OF_CONDUCT.md). By contributing to this project, you
+agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ dat <- data.frame(assay = "foo", b = 2)
 check_annotation_keys(dat)
 check_annotation_values(dat)
 ```
+
+Please note that the dccvalidator project is released with a
+[Contributor Code of Conduct](.github/CODE_OF_CONDUCT.md). By
+contributing to this project, you agree to abide by its terms.


### PR DESCRIPTION
Since @milen-sage is planning to work on this repo it's time for the project to adopt some contributing guidelines and for me to stop pushing directly to master. I added some standard contributing guidelines with the help of the usethis package, and modified them slightly for this package. @milen-sage let me know if this looks ok to you.