### PR TITLE
Check annotation value type when there are no enumerated values for the key

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ Imports:
 Suggests: 
     fs,
     testthat,
+    tibble,
     covr
 Additional_repositories:
     https://sage-bionetworks.github.io/ran

--- a/R/check-annotation-keys.R
+++ b/R/check-annotation-keys.R
@@ -6,7 +6,7 @@
 #'
 #' @param x An object to check.
 #' @param annotations A data frame of annotation definitions. Must contain at
-#'   least two columns: `key` and `value`.
+#'   least three columns: `key`, `value`, and `columnType`.
 #' @return A character vector of invalid (for `check_annotation_keys()`) or
 #'   valid (for `valid_annotation_keys()`) annotation keys present in `x`.
 #' @export
@@ -120,6 +120,12 @@ check_keys <- function(x, annotations, return_valid = FALSE) {
   }
   if (missing(annotations)) {
     annotations <- syndccutils::get_synapse_annotations()
+  }
+  if (!all(c("key", "value", "columnType") %in% names(annotations))) {
+    stop(
+      "Annotations must have the following columns: 'key', 'value', and 'columnType'",
+      call. = FALSE
+    )
   }
   if (isTRUE(return_valid)) {
     keys <- intersect(x, annotations$key)

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -174,6 +174,12 @@ check_values <- function(x, annotations, return_valid = FALSE) {
   if (missing(annotations)) {
     annotations <- syndccutils::get_synapse_annotations()
   }
+  if (!all(c("key", "value", "columnType") %in% names(annotations))) {
+    stop(
+      "Annotations must have the following columns: 'key', 'value', and 'columnType'",
+      call. = FALSE
+    )
+  }
   values <- purrr::imap(x, check_value, annotations, return_valid = return_valid)
   values <- purrr::compact(values)
 

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -18,7 +18,11 @@
 #' my_file <- synGet("syn11931757", downloadFile = FALSE)
 #' check_annotation_values(my_file, annots)
 #'
-#' dat <- data.frame(non_annotation = 5, assay = "rnaSeq")
+#' dat <- data.frame(
+#'   non_annotation = 5:7,
+#'   assay = c("rnaSeq", "foo", "bar"),
+#'   stringsAsFactors = FALSE
+#' )
 #' check_annotation_values(dat, annots)
 #'
 #' fv <- synTableQuery("SELECT * FROM syn17020234")

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -135,8 +135,7 @@ check_type <- function(value, key, annotations, return_valid = FALSE) {
 
   ## Check if class matches
   matches <- class(value) == correct_class
-  if (isTRUE(return_valid & matches)
-      | isFALSE(return_valid) & isFALSE(matches)) {
+  if (return_valid & matches | !return_valid & !matches) {
     return(value)
   } else {
     return(character(0))

--- a/man/check_annotation_keys.Rd
+++ b/man/check_annotation_keys.Rd
@@ -13,7 +13,7 @@ valid_annotation_keys(x, annotations)
 \item{x}{An object to check.}
 
 \item{annotations}{A data frame of annotation definitions. Must contain at
-least two columns: \code{key} and \code{value}.}
+least three columns: \code{key}, \code{value}, and \code{columnType}.}
 }
 \value{
 A character vector of invalid (for \code{check_annotation_keys()}) or

--- a/man/check_annotation_values.Rd
+++ b/man/check_annotation_values.Rd
@@ -13,7 +13,7 @@ valid_annotation_values(x, annotations)
 \item{x}{An object to check.}
 
 \item{annotations}{A data frame of annotation definitions. Must contain at
-least two columns: \code{key} and \code{value}.}
+least three columns: \code{key}, \code{value}, and \code{columnType}.}
 }
 \value{
 A named list of invalid annotation values.

--- a/man/check_annotation_values.Rd
+++ b/man/check_annotation_values.Rd
@@ -33,7 +33,11 @@ annots <- get_synapse_annotations()
 my_file <- synGet("syn11931757", downloadFile = FALSE)
 check_annotation_values(my_file, annots)
 
-dat <- data.frame(non_annotation = 5, assay = "rnaSeq")
+dat <- data.frame(
+  non_annotation = 5:7,
+  assay = c("rnaSeq", "foo", "bar"),
+  stringsAsFactors = FALSE
+)
 check_annotation_values(dat, annots)
 
 fv <- synTableQuery("SELECT * FROM syn17020234")

--- a/tests/testthat/test-check-annotation-keys.R
+++ b/tests/testthat/test-check-annotation-keys.R
@@ -1,28 +1,29 @@
 context("test-check-annotation-keys.R")
 
 library("synapser")
+library("tibble")
 if (on_travis()) syn_travis_login() else synLogin()
 annots <- syndccutils::get_synapse_annotations()
 
 test_that("check_annotation_keys returns character(0) when no invalid annotations present", {
-  dat <- data.frame(assay = "rnaSeq")
+  dat <- tibble(assay = "rnaSeq")
   res <- check_annotation_keys(dat, annots)
   expect_equal(res, character(0))
 })
 
 test_that("check_annotation_keys errors when no data provided", {
-  dat <- data.frame()
+  dat <- tibble()
   expect_error(check_annotation_keys(dat, annots))
 })
 
 test_that("check_annotation_keys returns invalid annotation values", {
-  dat <- data.frame(a = 1, b = 2)
+  dat <- tibble(a = 1, b = 2)
   suppressMessages(res <- check_annotation_keys(dat, annots))
   expect_equal(res, names(dat))
 })
 
 test_that("check_annotation_keys provides message", {
-  dat <- data.frame(a = 1, b = 2)
+  dat <- tibble(a = 1, b = 2)
   expect_message(check_annotation_keys(dat, annots))
 })
 
@@ -50,8 +51,8 @@ test_that("report_keys creates a message", {
 })
 
 test_that("valid_annotation_keys returns valid annotation keys", {
-  dat1 <- data.frame(assay = "rnaSeq")
-  dat2 <- data.frame(assay = "rnaSeq", fileFormat = "fastq")
+  dat1 <- tibble(assay = "rnaSeq")
+  dat2 <- tibble(assay = "rnaSeq", fileFormat = "fastq")
   res1 <- suppressMessages(valid_annotation_keys(dat1, annots))
   res2 <- suppressMessages(valid_annotation_keys(dat2, annots))
   expect_equal(res1, "assay")
@@ -97,7 +98,7 @@ test_that("check_keys falls back to get_synapse_annotations", {
 })
 
 test_that("check_keys checks that necessary annotation columns are present", {
-  annotations <- data.frame(key = "x", value = NA)
+  annotations <- tibble(key = "x", value = NA)
   a <- tibble(x = c("a", "b"))
   expect_error(check_keys(a, annotations))
 })

--- a/tests/testthat/test-check-annotation-keys.R
+++ b/tests/testthat/test-check-annotation-keys.R
@@ -95,3 +95,9 @@ test_that("check_keys falls back to get_synapse_annotations", {
   res <- suppressMessages(check_keys("not a key", return_valid = FALSE))
   expect_equal(res, "not a key")
 })
+
+test_that("check_keys checks that necessary annotation columns are present", {
+  annotations <- data.frame(key = "x", value = NA)
+  a <- tibble(x = c("a", "b"))
+  expect_error(check_keys(a, annotations))
+})

--- a/tests/testthat/test-check-annotation-values.R
+++ b/tests/testthat/test-check-annotation-values.R
@@ -200,3 +200,9 @@ test_that("check_type can handle factor annotation values as strings", {
     check_value(b, "x", annotations, return_valid = FALSE),
   )
 })
+
+test_that("check_values checks that necessary annotation columns are present", {
+  annotations <- tibble(key = "x", value = NA)
+  a <- tibble(x = c("a", "b"))
+  expect_error(check_values(a, annotations))
+})


### PR DESCRIPTION
Closes #23. Some of our annotations only specify a column type, not a list of enumerated values. Previously, any value for these annotations was considered invalid. With this PR, `check_annotation_values()` will not consider these invalid, and will instead compare the value's type with the `columnType` value in the annotation definition and only return values whose types don't match. There are still a few issues due to the way we define annotations, and the way they are represented by synapser:

1. some annotations should be more flexible in their definition. For example, `readLength` has type string, but should really also allow numeric; numeric read lengths will therefore be returned as invalid. `specimenID` should also be able to be numeric or string, but is defined as string only. There are a few other cases like this.
2. when retrieving boolean annotations from Synapse, synapser interprets `true` and `false` as strings, not logical.

In working on this I also realized we could simplify slightly the return format of `check_annotation_values()` -- it now returns a list of vectors instead of a list of lists.