### PR TITLE
Remove messages

### DIFF
--- a/R/check-annotation-keys.R
+++ b/R/check-annotation-keys.R
@@ -129,17 +129,8 @@ check_keys <- function(x, annotations, return_valid = FALSE) {
   }
   if (isTRUE(return_valid)) {
     keys <- intersect(x, annotations$key)
-    report_keys("Valid keys: ", keys)
   } else {
     keys <- setdiff(x, annotations$key)
-    report_keys("Invalid keys: ", keys)
   }
-  invisible(keys)
-}
-
-report_keys <- function(message, keys) {
-  if (length(keys) > 0) {
-    message(message)
-    message(paste0(keys, collapse = ", "))
-  }
+  keys
 }

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -181,21 +181,5 @@ check_values <- function(x, annotations, return_valid = FALSE) {
   }
   values <- purrr::imap(x, check_value, annotations, return_valid = return_valid)
   values <- purrr::compact(values)
-
-  if (isTRUE(return_valid)) {
-    report_values("Valid values: ", values)
-  } else {
-    report_values("Invalid values: ", values)
-  }
-  invisible(values)
-}
-
-report_values <- function(message, values) {
-  if (length(values) > 0) {
-    message(message)
-    purrr::iwalk(
-      values,
-      ~ message(paste0(.y, ": ", paste0("\"", .x, "\"", collapse = ", ")))
-    )
-  }
+  values
 }

--- a/tests/testthat/test-check-annotation-keys.R
+++ b/tests/testthat/test-check-annotation-keys.R
@@ -18,13 +18,8 @@ test_that("check_annotation_keys errors when no data provided", {
 
 test_that("check_annotation_keys returns invalid annotation values", {
   dat <- tibble(a = 1, b = 2)
-  suppressMessages(res <- check_annotation_keys(dat, annots))
+  res <- check_annotation_keys(dat, annots)
   expect_equal(res, names(dat))
-})
-
-test_that("check_annotation_keys provides message", {
-  dat <- tibble(a = 1, b = 2)
-  expect_message(check_annotation_keys(dat, annots))
 })
 
 test_that("check_annotation_keys works for File objects", {
@@ -32,8 +27,8 @@ test_that("check_annotation_keys works for File objects", {
 
   a <- synGet("syn17038064", downloadFile = FALSE)
   b <- synGet("syn17038065", downloadFile = FALSE)
-  resa <- suppressMessages(check_annotation_keys(a, annots))
-  resb <- suppressMessages(check_annotation_keys(b, annots))
+  resa <- check_annotation_keys(a, annots)
+  resb <- check_annotation_keys(b, annots)
   expect_equal(resa, character(0))
   expect_equal(resb, "randomAnnotation")
 })
@@ -42,19 +37,15 @@ test_that("check_annotation_keys works for file views", {
   skip_on_cran()
 
   fv <- synTableQuery("SELECT * FROM syn17038067")
-  res <- suppressMessages(check_annotation_keys(fv, annots))
+  res <- check_annotation_keys(fv, annots)
   expect_equal(res, "randomAnnotation")
-})
-
-test_that("report_keys creates a message", {
-  expect_message(report_keys("a message:", "foo"))
 })
 
 test_that("valid_annotation_keys returns valid annotation keys", {
   dat1 <- tibble(assay = "rnaSeq")
   dat2 <- tibble(assay = "rnaSeq", fileFormat = "fastq")
-  res1 <- suppressMessages(valid_annotation_keys(dat1, annots))
-  res2 <- suppressMessages(valid_annotation_keys(dat2, annots))
+  res1 <- valid_annotation_keys(dat1, annots)
+  res2 <- valid_annotation_keys(dat2, annots)
   expect_equal(res1, "assay")
   expect_equal(res2, c("assay", "fileFormat"))
 })
@@ -64,8 +55,8 @@ test_that("valid_annotation_keys works for File objects", {
 
   a <- synGet("syn17038064", downloadFile = FALSE)
   b <- synGet("syn17038065", downloadFile = FALSE)
-  resa <- suppressMessages(valid_annotation_keys(a, annots))
-  resb <- suppressMessages(valid_annotation_keys(b, annots))
+  resa <- valid_annotation_keys(a, annots)
+  resb <- valid_annotation_keys(b, annots)
   expect_equal(resa, "fileFormat")
   ## Sort because I think Synapse doesn't always return the same order
   expect_equal(sort(resb), c("assay", "fileFormat", "species"))
@@ -74,7 +65,7 @@ test_that("valid_annotation_keys works for File objects", {
 test_that("valid_annotation_keys works for file views", {
   skip_on_cran()
   fv <- synTableQuery("SELECT * FROM syn17038067")
-  res <- suppressMessages(valid_annotation_keys(fv, annots))
+  res <- valid_annotation_keys(fv, annots)
   ## Sort because I think Synapse doesn't always return the same order
   expect_equal(sort(res), c("assay", "fileFormat", "species"))
 })
@@ -82,10 +73,10 @@ test_that("valid_annotation_keys works for file views", {
 test_that("check_keys", {
   test_valid <- "fileFormat"
   test_invalid <- "not a key"
-  a1 <- suppressMessages(check_keys(test_valid, annots, return_valid = TRUE))
-  a2 <- suppressMessages(check_keys(test_valid, annots, return_valid = FALSE))
-  b1 <- suppressMessages(check_keys(test_invalid, annots, return_valid = TRUE))
-  b2 <- suppressMessages(check_keys(test_invalid, annots, return_valid = FALSE))
+  a1 <- check_keys(test_valid, annots, return_valid = TRUE)
+  a2 <- check_keys(test_valid, annots, return_valid = FALSE)
+  b1 <- check_keys(test_invalid, annots, return_valid = TRUE)
+  b2 <- check_keys(test_invalid, annots, return_valid = FALSE)
   expect_equal(a1, "fileFormat")
   expect_equal(a2, character(0))
   expect_equal(b1, character(0))
@@ -93,7 +84,7 @@ test_that("check_keys", {
 })
 
 test_that("check_keys falls back to get_synapse_annotations", {
-  res <- suppressMessages(check_keys("not a key", return_valid = FALSE))
+  res <- check_keys("not a key", return_valid = FALSE)
   expect_equal(res, "not a key")
 })
 

--- a/tests/testthat/test-check-annotation-values.R
+++ b/tests/testthat/test-check-annotation-values.R
@@ -18,21 +18,16 @@ test_that("check_annotation_values errors when there are no annotations to check
 
 test_that("check_annotation_values returns invalid annotation values", {
   dat <- tibble(assay = "foo", consortium = "bar")
-  res <- suppressMessages(check_annotation_values(dat, annots))
+  res <- check_annotation_values(dat, annots)
   expect_equal(res, list(assay = "foo", consortium = "bar"))
-})
-
-test_that("check_annotation_values provides message", {
-  dat <- tibble(assay = "foo", b = 2)
-  expect_message(check_annotation_values(dat, annots))
 })
 
 test_that("check_annotation_values works for File objects", {
   skip_on_cran()
   a <- synGet("syn17038064", downloadFile = FALSE)
   b <- synGet("syn17038065", downloadFile = FALSE)
-  resa <- suppressMessages(check_annotation_values(a, annots))
-  resb <- suppressMessages(check_annotation_values(b, annots))
+  resa <- check_annotation_values(a, annots)
+  resb <- check_annotation_values(b, annots)
   expect_equal(resa, structure(list(), .Names = character(0)))
   expect_equal(
     resb[order(names(resb))], # need to ensure these are in the right order,
@@ -44,19 +39,19 @@ test_that("check_annotation_values works for File objects", {
 test_that("check_annotation_values works for file views", {
   skip_on_cran()
   fv <- synTableQuery("SELECT * FROM syn17038067")
-  res <- suppressMessages(check_annotation_values(fv, annots))
+  res <- check_annotation_values(fv, annots)
   expect_equal(res, list(assay = "wrongAssay", species = "wrongSpecies"))
 })
 
 test_that("check annotation values returns unique wrong values, not every single one", {
   dat <- tibble(assay = c("foo", "foo", "rnaSeq"))
-  res <- suppressMessages(check_annotation_values(dat, annots))
+  res <- check_annotation_values(dat, annots)
   expect_equal(res, list(assay = "foo"))
 })
 
 test_that("valid_annotation_values returns valid values", {
   dat <- tibble(assay = "rnaSeq")
-  res <- suppressMessages(valid_annotation_values(dat, annots))
+  res <- valid_annotation_values(dat, annots)
   ## Returns list of valid values
   expect_equal(res, list(assay = "rnaSeq"))
 })
@@ -69,14 +64,14 @@ test_that("valid_annotation_values fails when no annotations present", {
 test_that("valid_annotation_values works for File objects", {
   skip_on_cran()
   a <- synGet("syn17038064", downloadFile = FALSE)
-  resa <- suppressMessages(valid_annotation_values(a, annots))
+  resa <- valid_annotation_values(a, annots)
   expect_equal(resa, list(fileFormat = "txt"))
 })
 
 test_that("check_annotation_values works for file views", {
   skip_on_cran()
   fv <- synTableQuery("SELECT * FROM syn17038067")
-  res <- suppressMessages(valid_annotation_values(fv, annots))
+  res <- valid_annotation_values(fv, annots)
   ## Slightly awkward test because synapse seems to return the values in
   ## different orders sometimes
   expect_equal(names(res), "fileFormat")
@@ -96,8 +91,8 @@ test_that("check_value returns valid or invalid valies", {
 
 test_that("check_values checks multiple values", {
   dat <- tibble(fileFormat = c("wrong", "txt", "csv", "wrong again"))
-  resa <- suppressMessages(check_values(dat, annots, return_valid = TRUE))
-  resb <- suppressMessages(check_values(dat, annots, return_valid = FALSE))
+  resa <- check_values(dat, annots, return_valid = TRUE)
+  resb <- check_values(dat, annots, return_valid = FALSE)
   expect_equal(
     resa,
     list(fileFormat = c("txt", "csv"))
@@ -110,9 +105,7 @@ test_that("check_values checks multiple values", {
 
 
 test_that("check_value falls back to get_synapse_annotations", {
-  res <- suppressMessages(
-    check_value("wrong", "fileFormat", return_valid = FALSE)
-  )
+  res <- check_value("wrong", "fileFormat", return_valid = FALSE)
   expect_equal(res, "wrong")
   ## Should be the same as passing in annots:
   expect_equal(


### PR DESCRIPTION
Closes #14. Instead of providing a message and returning keys/values invisibly, `check_annotation_keys()` and `check_annotation_values()` (as well as their counterparts `valid_annotation_keys()` and `valid_annotation_values()` just return the vector or list of keys/values normally.