### PR TITLE
Add .Rproj file

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,5 @@
 ^\.travis\.yml$
 ^codecov\.yml$
 ^data-raw/
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/dccvalidator.Rproj
+++ b/dccvalidator.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
Adds a dccvalidator.Rproj file: useful for people who may be working on development using RStudio.