### PR TITLE
Use addResourcePath() to find css and js resources

### DIFF
--- a/R/app-ui.R
+++ b/R/app-ui.R
@@ -132,12 +132,15 @@ app_ui <- function(request) {
 
 #' @import shiny
 golem_add_external_resources <- function() {
+
+  addResourcePath(
+    "www", system.file("app/www", package = "dccvalidator")
+  )
+
   tags$head(
     golem::activate_js(),
     golem::favicon(),
-    includeCSS("inst/app/www/custom.css"),
-    singleton(
-      includeScript("inst/app/www/readCookie.js")
-    )
+    tags$link(rel = "stylesheet", type = "text/css", href = "www/custom.css"),
+    tags$script(src = "www/readCookie.js")
   )
 }


### PR DESCRIPTION
I believe this is the recommended way to load external resources (custom CSS and the javascript we use to check authentication) with Shiny, and should allow an app to find these resources as long as dccvalidator is installed, even if the app is stored in a different location.