### PR TITLE
Add pre-commit hooks for code quality checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+-   repo: https://github.com/lorenzwalthert/pre-commit-hooks
+    rev: v0.0.0.9016
+    hooks:
+    -   id: style-files
+    -   id: parsable-R
+    -   id: no-browser-statement
+    -   id: readme-rmd-rendered
+    -   id: roxygenize
+    -   id: use-tidy-description
+    -   id: lintr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,19 +1,24 @@
 Package: dccvalidator
-Version: 0.0.0.9002
 Title: Validate CNS Data and Metadata
-Description: Performs automatic checks for common data/metadata quality issues.
-Authors@R: c(
-    person("Kara", "Woo", email = "kara.woo@sagebase.org", role = c("aut", "cre")),
-    person("Sage Bionetworks", role = c("cph"))
-    )
+Version: 0.0.0.9002
+Authors@R: 
+    c(person(given = "Kara",
+             family = "Woo",
+             role = c("aut", "cre"),
+             email = "kara.woo@sagebase.org"),
+      person(given = "Sage Bionetworks",
+             role = "cph"))
+Description: Performs automatic checks for common data/metadata quality
+    issues.
+License: MIT + file LICENSE
 Depends:
     R (>= 3.4),
     shinyBS
 Imports:
-    emo,
     DT,
-    golem,
+    emo,
     ggplot2,
+    golem,
     pkgload,
     purrr,
     readxl,
@@ -29,16 +34,14 @@ Imports:
     utils,
     visdat
 Suggests:
-    testthat,
-    covr
-Additional_repositories:
-    http://ran.synapse.org
+    covr,
+    testthat
 Remotes:
     hadley/emo,
     Sage-Bionetworks/syndccutils/R
-License: MIT + file LICENSE
+Additional_repositories: http://ran.synapse.org
+ByteCompile: true
 Encoding: UTF-8
 LazyData: true
-ByteCompile: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1

--- a/README.Rmd
+++ b/README.Rmd
@@ -34,6 +34,10 @@ You can check whether a Synapse file has valid annotation keys and values. You
 can also check file views and data frames to see if their columns correspond to
 valid annotations, and if the values in the columns are valid.
 
+```{r load, echo = FALSE}
+pkgload::load_all()
+```
+
 ```{r login, message = FALSE, results = "hide"}
 library("synapser")
 library("dccvalidator")
@@ -140,6 +144,24 @@ stand up a new version that is customized for a different community):
 
 Again, you may need to run `touch restart.txt` afterward to ensure the
 application is restarted.
+
+## Local development
+
+`dccvalidator` uses pre-commit hooks to check for common issues, such as code
+style (which should conform to [tidyverse style](https://style.tidyverse.org/)),
+code parsability, and up-to-date .Rd documentation. To use, you will need to
+install [pre-commit](https://pre-commit.com/#intro). If on a Mac, I recommend
+using [homebrew](https://brew.sh/):
+
+```
+brew install pre-commit
+```
+
+Then, within this git repo, run:
+
+```
+pre-commit install
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ values. You can also check file views and data frames to see if their
 columns correspond to valid annotations, and if the values in the
 columns are valid.
 
+    #> Loading dccvalidator
+    #> Loading required package: shinyBS
+
 ``` r
 library("synapser")
 library("dccvalidator")
@@ -48,7 +51,7 @@ check_annotation_values(my_file, annots)
 fv <- synTableQuery("SELECT * FROM syn17038067")
 #> 
  [####################]100.00%   1/1   Done...    
-Downloading  [####################]100.00%   3.2kB/3.2kB (1.1MB/s) Job-96833558741870820474626635.csv Done...
+Downloading  [####################]100.00%   3.2kB/3.2kB (1.2MB/s) Job-97181474099481724820214930.csv Done...
 check_annotation_keys(fv, annots)
 #> <error>
 #> message: Some annotation keys are invalid
@@ -177,6 +180,21 @@ community):
 
 Again, you may need to run `touch restart.txt` afterward to ensure the
 application is restarted.
+
+## Local development
+
+`dccvalidator` uses pre-commit hooks to check for common issues, such as
+code style (which should conform to [tidyverse
+style](https://style.tidyverse.org/)), code parsability, and up-to-date
+.Rd documentation. To use, you will need to install
+[pre-commit](https://pre-commit.com/#intro). If on a Mac, I recommend
+using [homebrew](https://brew.sh/):
+
+    brew install pre-commit
+
+Then, within this git repo, run:
+
+    pre-commit install
 
 -----
 

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "renv": {
-    "Version": "0.7.0-41"
+    "Version": "0.7.0-94"
   },
   "R": {
     "Version": "3.6.0",
@@ -47,28 +47,28 @@
     "BH": {
       "Package": "BH",
       "Version": "1.69.0-1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "0fde015f5153e51df44981da0767f522"
     },
     "DT": {
       "Package": "DT",
       "Version": "0.7",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "981ae58e8b540dd02bb331dbef40d130"
     },
     "MASS": {
       "Package": "MASS",
       "Version": "7.3-51.4",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "a489ad42493fa9bfac8f3e3a3bc7d4ca"
     },
     "Matrix": {
       "Package": "Matrix",
       "Version": "1.2-17",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "a60009c832f495604f54399f21d89cc8"
     },
@@ -85,196 +85,196 @@
     "R6": {
       "Package": "R6",
       "Version": "2.4.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "92b50d943a7c76c67918c1e1beb68627"
     },
     "RColorBrewer": {
       "Package": "RColorBrewer",
       "Version": "1.1-2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "f8a3bcc800d613797f1dfdf8ef4f0bfc"
     },
     "RCurl": {
       "Package": "RCurl",
       "Version": "1.95-4.12",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "da83dfabbb92098a20dada46869921a3"
     },
     "Rcpp": {
       "Package": "Rcpp",
       "Version": "1.0.2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "c25fa7d5684fa7001ddfea3755243975"
     },
     "askpass": {
       "Package": "askpass",
       "Version": "1.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "46678e19f261db289be40292d8e5d5bf"
     },
     "assertthat": {
       "Package": "assertthat",
       "Version": "0.2.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "19fb3d0ad048b4eb1a05cacffbae1f66"
     },
     "attempt": {
       "Package": "attempt",
       "Version": "0.3.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "abccf986dbdc6ae32ee72d0107ba7587"
     },
     "backports": {
       "Package": "backports",
       "Version": "1.1.4",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "2a78bf0825e0088e117520553ceb7fa5"
     },
     "base64enc": {
       "Package": "base64enc",
       "Version": "0.1-3",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "d355963b4b1c3039bfe8d65611a11cca"
     },
     "bitops": {
       "Package": "bitops",
       "Version": "1.0-6",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "62408262624d9f8e436f51ca901424e2"
     },
     "brew": {
       "Package": "brew",
       "Version": "1.0-6",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "190fd31e9253446523a8ee4642229516"
     },
     "callr": {
       "Package": "callr",
       "Version": "3.2.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "f1e3e635828bc08b88fc70a722800df5"
     },
     "cellranger": {
       "Package": "cellranger",
       "Version": "1.1.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "2cd2a065192f3ba08a919d8800dba7e0"
     },
     "cli": {
       "Package": "cli",
       "Version": "1.1.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "9b3dc7798f53ba3050b41ce4a3febdc5"
     },
     "clipr": {
       "Package": "clipr",
       "Version": "0.7.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "9a99b54d2baf9393d0a68b6ea9513ee6"
     },
     "clisymbols": {
       "Package": "clisymbols",
       "Version": "1.2.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "ce91c46caba29e30c44cfd87659bf8a4"
     },
     "colorspace": {
       "Package": "colorspace",
       "Version": "1.4-1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "c25d49739abb6ebf4b3d0c3565574226"
     },
     "commonmark": {
       "Package": "commonmark",
       "Version": "1.7",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "af7f698e0328e0474f794452177deca6"
     },
     "covr": {
       "Package": "covr",
       "Version": "3.2.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "82c22e908d49b7bdc03016864ef0b9b8"
     },
     "crayon": {
       "Package": "crayon",
       "Version": "1.3.4",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "d308ead32010b8e4d76c4690427da50b"
     },
     "crosstalk": {
       "Package": "crosstalk",
       "Version": "1.0.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "2bc962d85f29df259cc1a6930727ce87"
     },
     "curl": {
       "Package": "curl",
       "Version": "4.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "7dc1d02a04a75510424d2c7404fadfa7"
     },
     "data.table": {
       "Package": "data.table",
       "Version": "1.12.2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "f2f76b5c5394350c4d4ee77dab51d35c"
     },
     "desc": {
       "Package": "desc",
       "Version": "1.2.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "0119aa659b9c1db195b4bd7c617d18c0"
     },
     "devtools": {
       "Package": "devtools",
       "Version": "2.0.2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "7c464263bfa1c55ebada53c6d851812f"
     },
     "digest": {
       "Package": "digest",
       "Version": "0.6.20",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "e90f6670040b5aec92425051fc13ac1c"
     },
     "dockerfiler": {
       "Package": "dockerfiler",
       "Version": "0.1.3",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "2fa7e591556180db4964ea761268af7c"
     },
     "dplyr": {
       "Package": "dplyr",
       "Version": "0.8.2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "fca1b2f4014ca9316d8de0d630e5ff59"
     },
@@ -306,35 +306,35 @@
     "evaluate": {
       "Package": "evaluate",
       "Version": "0.14",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "5a6c1949963e0785dbcbb0556337d61e"
     },
     "fansi": {
       "Package": "fansi",
       "Version": "0.4.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "cd87b0162287f0da225edfaa2fd3a20c"
     },
     "feather": {
       "Package": "feather",
       "Version": "0.3.3",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "33df40b9417ea77af76973bb2ea92164"
     },
     "forcats": {
       "Package": "forcats",
       "Version": "0.4.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "4d7e4a2ed5adadda6714eb7b9361213b"
     },
     "fs": {
       "Package": "fs",
       "Version": "1.3.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "dba7e43c4103d978cb7c95b97987cc68"
     },
@@ -353,14 +353,14 @@
     "gh": {
       "Package": "gh",
       "Version": "1.0.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "3fc5d4d6893bd1598318a35def5e9d23"
     },
     "git2r": {
       "Package": "git2r",
       "Version": "0.26.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "22ea14e8f582d4a83a273f24ac43e27e"
     },
@@ -379,182 +379,182 @@
     "golem": {
       "Package": "golem",
       "Version": "0.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "bca2a5efeb4be5f492327956f4117071"
     },
     "gtable": {
       "Package": "gtable",
       "Version": "0.3.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "6a58b2980a57345822ec5f9c7d2d1751"
     },
     "hexbin": {
       "Package": "hexbin",
       "Version": "1.27.3",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "dd1a219a8e8212b1808640670893274e"
     },
     "highr": {
       "Package": "highr",
       "Version": "0.8",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "43e36bc8bca1d8256f86933659c46349"
     },
     "hms": {
       "Package": "hms",
       "Version": "0.5.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "092e5b11e8fb83b420b1a192ab095263"
     },
     "htmltools": {
       "Package": "htmltools",
       "Version": "0.3.6",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "5132526e7fb28a2c20d1ef443d5c4644"
     },
     "htmlwidgets": {
       "Package": "htmlwidgets",
       "Version": "1.3",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "8aa0ed21f14fc9645367e8bc305415f5"
     },
     "httpuv": {
       "Package": "httpuv",
       "Version": "1.5.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "3e4206eb62d89401a2a990eba9b3ecac"
     },
     "httr": {
       "Package": "httr",
       "Version": "1.4.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "4a241c31afac61ea4a8a672aa5b0b098"
     },
     "ini": {
       "Package": "ini",
       "Version": "0.3.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "4a15d8cfc931554fb2e71d66c1313b45"
     },
     "jsonlite": {
       "Package": "jsonlite",
       "Version": "1.6",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "b7e67b6a7bc2fdae729c0f3ff9026a8a"
     },
     "knitr": {
       "Package": "knitr",
       "Version": "1.23",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "39893fe4cbbdca3fce7d9dbdef808cd1"
     },
     "labeling": {
       "Package": "labeling",
       "Version": "0.3",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "e1f613894f080d1eee41c34b281a2184"
     },
     "later": {
       "Package": "later",
       "Version": "0.8.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "4d5b806a328e0da75f0f0d4653676552"
     },
     "lattice": {
       "Package": "lattice",
       "Version": "0.20-38",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "6f7aa123115b33bc9ad1ca800874b1de"
     },
     "lazyeval": {
       "Package": "lazyeval",
       "Version": "0.2.2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "d2f5e98b8b7ae633e252830c3243c2ab"
     },
     "lubridate": {
       "Package": "lubridate",
       "Version": "1.7.4",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "d55fdb3732a8f047e49b86064dd78984"
     },
     "magrittr": {
       "Package": "magrittr",
       "Version": "1.5",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "dee1d97cffddfd3ed969e224bd0826d0"
     },
     "markdown": {
       "Package": "markdown",
       "Version": "1.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "4584a57f565dd7987d59dda3a02cfb41"
     },
     "memoise": {
       "Package": "memoise",
       "Version": "1.1.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "22ca9b285c10f5dd8c4d1e90231ce558"
     },
     "mgcv": {
       "Package": "mgcv",
       "Version": "1.8-28",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "6ac256e4fdcf33c11f9ed987927cc614"
     },
     "mime": {
       "Package": "mime",
       "Version": "0.7",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "908d95ccbfd1dd274073ef07a7c93934"
     },
     "munsell": {
       "Package": "munsell",
       "Version": "0.5.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "9111af6c6dec65538ebd3de6c0bae864"
     },
     "nlme": {
       "Package": "nlme",
       "Version": "3.1-140",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "ad3b02c6f154deac3584133e6e015cd3"
     },
     "openssl": {
       "Package": "openssl",
       "Version": "1.4.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "6c438de366d5693238d1c400deb66cb6"
     },
     "openxlsx": {
       "Package": "openxlsx",
       "Version": "4.1.0.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "70d7bf3b6565c00c63421240dfac651c"
     },
@@ -571,140 +571,140 @@
     "packrat": {
       "Package": "packrat",
       "Version": "0.5.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "aa1fbebb6ca276f933b9f77da6d02ef3"
     },
     "pander": {
       "Package": "pander",
       "Version": "0.6.3",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "ccc723b9d7b4db7ef57a6109d7835380"
     },
     "pillar": {
       "Package": "pillar",
       "Version": "1.4.2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "57645ff795277554eee14df5bcee8025"
     },
     "pkgbuild": {
       "Package": "pkgbuild",
       "Version": "1.0.3",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "1e8100d85ef7b9cddded115d62d7365a"
     },
     "pkgconfig": {
       "Package": "pkgconfig",
       "Version": "2.0.2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "2dd2d8867e4f0173ea2ce029d630a086"
     },
     "pkgload": {
       "Package": "pkgload",
       "Version": "1.0.2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "f214a72af3442fdd3396ceccbb7d7f44"
     },
     "plogr": {
       "Package": "plogr",
       "Version": "0.2.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "1a8304cc1382ef64e3b710ba589d7bc0"
     },
     "plotly": {
       "Package": "plotly",
       "Version": "4.9.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "d4f8ca9fa024657598c3698df2e12cfb"
     },
     "plyr": {
       "Package": "plyr",
       "Version": "1.8.4",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "37dd0f3aadee2ac99e47168f4bffddb7"
     },
     "praise": {
       "Package": "praise",
       "Version": "1.0.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "3940f2f321d5fa9fb72b8887b0454660"
     },
     "prettyunits": {
       "Package": "prettyunits",
       "Version": "1.0.2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "33ce93b23647e85c127f8e1bb08604fc"
     },
     "processx": {
       "Package": "processx",
       "Version": "3.3.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "6cb4a4d0e13190ea58a2ed9e39adf967"
     },
     "progress": {
       "Package": "progress",
       "Version": "1.2.2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "e8c47e04650b07d40c3c50a878a4dffa"
     },
     "promises": {
       "Package": "promises",
       "Version": "1.0.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "f80d162b7cef7e36a0134d1f1084e36d"
     },
     "ps": {
       "Package": "ps",
       "Version": "1.3.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "a38f3fd447d1595a3da538910054b911"
     },
     "purrr": {
       "Package": "purrr",
       "Version": "0.3.2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "c360ab7eabd6e38a83f2475eb97c6344"
     },
     "rcmdcheck": {
       "Package": "rcmdcheck",
       "Version": "1.3.3",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "577b91be8aea851ea27aad3585adef05"
     },
     "readr": {
       "Package": "readr",
       "Version": "1.3.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "60167b7ec3de99e76ff406aaf0f83bb4"
     },
     "readxl": {
       "Package": "readxl",
       "Version": "1.3.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "8a8b4695e87c90cc9423eb8994e76819"
     },
     "rematch": {
       "Package": "rematch",
       "Version": "1.0.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "d3d55a556f7f2e74f449d6a53b8abf8e"
     },
@@ -722,146 +722,153 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "0.7.0-41",
+      "Version": "0.7.0-94",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteRepo": "renv",
       "RemoteUsername": "rstudio",
+      "RemoteRepo": "renv",
       "RemoteRef": "master",
-      "RemoteSha": "6aa87ba2662be6f4eabf187a99cf1320b722c98e",
-      "Hash": "a0fc4096ccec58f8758f1d436b043a36"
+      "RemoteSha": "dfde0ebb7688fe9da46d9e12f564383660eef891",
+      "Hash": "a04da2100843bfa9822bc28a877a45b4"
     },
     "reshape2": {
       "Package": "reshape2",
       "Version": "1.4.3",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "ac685130d1a25e3f6470960fd29c5693"
     },
     "rex": {
       "Package": "rex",
       "Version": "1.1.2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "6a374bfb33486a98af825be15b6b87bb"
     },
     "rjson": {
       "Package": "rjson",
       "Version": "0.2.20",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "d3349736ec0f60d05591c316b926382e"
     },
     "rlang": {
       "Package": "rlang",
       "Version": "0.4.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "8f1bf3a54c8844dc254baabba61cb6a9"
+    },
+    "rmarkdown": {
+      "Package": "rmarkdown",
+      "Version": "1.15",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "7009ca49bab0c053098ae99b595bbacb"
     },
     "roxygen2": {
       "Package": "roxygen2",
       "Version": "6.1.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "5c44ac973ec9b56efd7990e4b4464699"
     },
     "rprojroot": {
       "Package": "rprojroot",
       "Version": "1.3-2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "5382761b8b318da6dd3fb0f6dae3c43a"
     },
     "rsconnect": {
       "Package": "rsconnect",
       "Version": "0.8.13",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "0d24a69088b3c09f81c10a91625d3ba2"
     },
     "rstudioapi": {
       "Package": "rstudioapi",
       "Version": "0.10",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "04552808fd065fdf0fec7bad340eb83c"
     },
     "rvest": {
       "Package": "rvest",
       "Version": "0.3.4",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "76bb112bc3833454dc701230aa9cb3ed"
     },
     "scales": {
       "Package": "scales",
       "Version": "1.0.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "a96e9571cd875b7b934990d85b7a3c18"
     },
     "selectr": {
       "Package": "selectr",
       "Version": "0.4-1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "40ccee5dc2b97e197648525aefcfd0ba"
     },
     "sessioninfo": {
       "Package": "sessioninfo",
       "Version": "1.1.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "017efbc7877606b886a2fb3d01c0bbda"
     },
     "shiny": {
       "Package": "shiny",
       "Version": "1.3.2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "3f96ad878877e005bcf6093c5c7efd9e"
     },
     "shinyBS": {
       "Package": "shinyBS",
       "Version": "0.61",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "09a0b3f7981711a00dc2477a7abc59ab"
     },
     "shinydashboard": {
       "Package": "shinydashboard",
       "Version": "0.7.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "12f87658587a6ea64a67e7d559d6491d"
     },
     "skimr": {
       "Package": "skimr",
       "Version": "1.0.7",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "9f6f41df5ca0786682825edd0eb84a3e"
     },
     "sourcetools": {
       "Package": "sourcetools",
       "Version": "0.1.7",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "fc68fa34b8576eaa5a845a46ad75e214"
     },
     "stringi": {
       "Package": "stringi",
       "Version": "1.4.3",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "113506f116db9dd5bd1caf46884e0647"
     },
     "stringr": {
       "Package": "stringr",
       "Version": "1.4.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "41d6310ad18bd019a203d7adc496a28b"
     },
@@ -892,21 +899,21 @@
     "sys": {
       "Package": "sys",
       "Version": "3.2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "272daf1b3ba287a42d02e33c89870eae"
     },
     "testthat": {
       "Package": "testthat",
       "Version": "2.1.1",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "6cdac1c005c81c36a89ba90835726f3f"
     },
     "tibble": {
       "Package": "tibble",
       "Version": "2.1.3",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "a8d41bd284e21ab7e776d228dc5bac91"
     },
@@ -926,9 +933,16 @@
     "tidyselect": {
       "Package": "tidyselect",
       "Version": "0.2.5",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "dc3fcbc21f04b293e0794e24982cf357"
+    },
+    "tinytex": {
+      "Package": "tinytex",
+      "Version": "0.15",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "11c9260eb54db1f55e7573844c2ae8ed"
     },
     "usethis": {
       "Package": "usethis",
@@ -945,98 +959,98 @@
     "utf8": {
       "Package": "utf8",
       "Version": "1.1.4",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "3f1a5a5b184f63379f8e6c08d5036c53"
     },
     "vctrs": {
       "Package": "vctrs",
       "Version": "0.2.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "4bdc6a6c4c5a434d880b73817d4ea641"
     },
     "viridisLite": {
       "Package": "viridisLite",
       "Version": "0.3.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "1f264fa42320c4f44b1689d89101e823"
     },
     "visdat": {
       "Package": "visdat",
       "Version": "0.5.3",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "9bda34c3ecc23952bae1bfa2f70471a4"
     },
     "whisker": {
       "Package": "whisker",
       "Version": "0.3-2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "c6d8a035a88c6e3222f0efaac18406f6"
     },
     "withr": {
       "Package": "withr",
       "Version": "2.1.2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "7c9aef08038f47e6c1532ed574a0e087"
     },
     "xfun": {
       "Package": "xfun",
       "Version": "0.7",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "6b504b3cf978ea44cb770b53e69b9f6c"
     },
     "xml2": {
       "Package": "xml2",
       "Version": "1.2.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "8a9818f279792f697dab45e8c7cdb3a8"
     },
     "xopen": {
       "Package": "xopen",
       "Version": "1.0.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "ec32d86b4bcfa2cfa648dc0e1e46e24d"
     },
     "xtable": {
       "Package": "xtable",
       "Version": "1.8-4",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "48f60fcc0974ce72870076d48038df2d"
     },
     "yaml": {
       "Package": "yaml",
       "Version": "2.2.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "3a313c96061c4ac790de611dc57ebd1f"
     },
     "yesno": {
       "Package": "yesno",
       "Version": "0.1.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "60425bff7e89ec3c31505ca8298bda01"
     },
     "zeallot": {
       "Package": "zeallot",
       "Version": "0.1.0",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "45d65588b02d47970fc84adecb2ee664"
     },
     "zip": {
       "Package": "zip",
       "Version": "2.0.2",
-      "Source": "CRAN",
+      "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "c61c60b9aa516596641a141e6af5f5f8"
     }

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,7 +2,7 @@
 local({
 
   # the requested version of renv
-  version <- "0.7.0-41"
+  version <- "0.7.0-94"
 
   # signal that we're loading renv during R startup
   Sys.setenv("RENV_R_INITIALIZING" = "true")
@@ -112,11 +112,25 @@ local({
     utils::download.file(url, destfile = destfile, mode = "wb", quiet = TRUE)
     message("Done!")
 
-    # attempt to install it into bootstrap library
+    # attempt to install it into project library
     message("* Installing renv ", version, " ... ", appendLF = FALSE)
     dir.create(libpath, showWarnings = FALSE, recursive = TRUE)
-    utils::install.packages(destfile, repos = NULL, type = "source", lib = libpath, quiet = TRUE)
+
+    # invoke using system2 so we can capture and report output
+    bin <- R.home("bin")
+    exe <- if (Sys.info()[["sysname"]] == "Windows") "R.exe" else "R"
+    r <- file.path(bin, exe)
+    args <- c("--vanilla", "CMD", "INSTALL", "-l", shQuote(libpath), shQuote(destfile))
+    output <- system2(r, args, stdout = TRUE, stderr = TRUE)
     message("Done!")
+
+    # check for successful install
+    status <- attr(output, "status")
+    if (is.numeric(status) && !identical(status, 0L)) {
+      text <- c("Error installing renv", "=====================", output)
+      writeLines(text, con = stderr())
+    }
+
 
   }
 


### PR DESCRIPTION
Uses [pre-commit](https://pre-commit.com/#intro) and standard R [pre-commit hooks](https://github.com/lorenzwalthert/pre-commit-hooks) to do the following before committing:
- Style R code according to tidyverse style with [styler](https://styler.r-lib.org/)
- Ensure R code files are parsable
- Ensure no errant `browser()` calls have been left in code
- Ensure that `README.Rmd` has been rendered so that `README.md` is up to date
- Render documentation files from roxygen2 comments
- Ensure the DESCRIPTION file follows recommended structure and order
- Performs linting on the code

Instructions have been added to the README on how to install `pre-commit` so that this works locally.