### PR TITLE
Warn about empty columns in metadata files and manifest

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -204,6 +204,37 @@ app_server <- function(input, output, session) {
       check_specimen_ids_dup(biosp())
     })
 
+    # Empty columns produce warnings -----------------------------------------------
+    empty_cols_manifest <- reactive({
+      check_cols_empty(
+        manifest(),
+        success_msg = "No columns are empty in the manifest",
+        fail_msg = "Some columns are empty in the manifest"
+      )
+    })
+    empty_cols_indiv <- reactive({
+      check_cols_empty(
+        indiv(),
+        success_msg = "No columns are empty in the individual metadata",
+        fail_msg = "Some columns are empty in the individual metadata"
+      )
+    })
+    empty_cols_biosp <- reactive({
+      check_cols_empty(
+        biosp(),
+        success_msg = "No columns are empty in the biospecimen metadata",
+        fail_msg = "Some columns are empty in the biospecimen metadata"
+      )
+    })
+    empty_cols_assay <- reactive({
+      check_cols_empty(
+        assay(),
+        success_msg = "No columns are empty in the assay metadata",
+        fail_msg = "Some columns are empty in the assay metadata"
+      )
+    })
+
+
     ## List results
     res <- reactive({
       list(
@@ -220,7 +251,11 @@ app_server <- function(input, output, session) {
         annotation_values_biosp(),
         annotation_values_assay(),
         duplicate_indiv_ids(),
-        duplicate_specimen_ids()
+        duplicate_specimen_ids(),
+        empty_cols_manifest(),
+        empty_cols_indiv(),
+        empty_cols_biosp(),
+        empty_cols_assay()
       )
     })
 

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -130,7 +130,7 @@ app_server <- function(input, output, session) {
 
     ## Perform checks
 
-    # Missing columns --------------------------------------------------------------
+    # Missing columns ----------------------------------------------------------
     missing_cols_indiv <- reactive({
       check_cols_individual(indiv(), species_name())
     })
@@ -144,7 +144,7 @@ app_server <- function(input, output, session) {
       check_cols_manifest(manifest())
     })
 
-    # Individual and specimen IDs match --------------------------------------------
+    # Individual and specimen IDs match ----------------------------------------
     individual_ids_indiv_biosp <- reactive({
       check_indiv_ids_match(indiv(), biosp(), "individual", "biospecimen")
     })
@@ -155,7 +155,7 @@ app_server <- function(input, output, session) {
       check_specimen_ids_match(biosp(), manifest(), "biospecimen", "manifest")
     })
 
-    # Annotation keys in manifest are valid ----------------------------------------
+    # Annotation keys in manifest are valid ------------------------------------
     annotation_keys_manifest <- reactive({
       check_annotation_keys(
         manifest(),
@@ -164,7 +164,7 @@ app_server <- function(input, output, session) {
       )
     })
 
-    # Annotation values in manifest and metadata are valid -------------------------
+    # Annotation values in manifest and metadata are valid ---------------------
     annotation_values_manifest <- reactive({
       check_annotation_values(manifest(), annots)
     })
@@ -196,7 +196,7 @@ app_server <- function(input, output, session) {
       )
     })
 
-    # Individual and specimen IDs are not duplicated -------------------------------
+    # Individual and specimen IDs are not duplicated ---------------------------
     duplicate_indiv_ids <- reactive({
       check_indiv_ids_dup(indiv())
     })
@@ -204,7 +204,7 @@ app_server <- function(input, output, session) {
       check_specimen_ids_dup(biosp())
     })
 
-    # Empty columns produce warnings -----------------------------------------------
+    # Empty columns produce warnings -------------------------------------------
     empty_cols_manifest <- reactive({
       check_cols_empty(
         manifest(),

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -129,6 +129,8 @@ app_server <- function(input, output, session) {
     ##############################
 
     ## Perform checks
+
+    # Missing columns --------------------------------------------------------------
     missing_cols_indiv <- reactive({
       check_cols_individual(indiv(), species_name())
     })
@@ -141,6 +143,8 @@ app_server <- function(input, output, session) {
     missing_cols_manifest <- reactive({
       check_cols_manifest(manifest())
     })
+
+    # Individual and specimen IDs match --------------------------------------------
     individual_ids_indiv_biosp <- reactive({
       check_indiv_ids_match(indiv(), biosp(), "individual", "biospecimen")
     })
@@ -150,6 +154,8 @@ app_server <- function(input, output, session) {
     specimen_ids_biosp_manifest <- reactive({
       check_specimen_ids_match(biosp(), manifest(), "biospecimen", "manifest")
     })
+
+    # Annotation keys in manifest are valid ----------------------------------------
     annotation_keys_manifest <- reactive({
       check_annotation_keys(
         manifest(),
@@ -157,6 +163,8 @@ app_server <- function(input, output, session) {
         whitelist_keys = c("path", "parent")
       )
     })
+
+    # Annotation values in manifest and metadata are valid -------------------------
     annotation_values_manifest <- reactive({
       check_annotation_values(manifest(), annots)
     })
@@ -187,6 +195,8 @@ app_server <- function(input, output, session) {
         fail_msg = "Some values in the assay metadata are invalid"
       )
     })
+
+    # Individual and specimen IDs are not duplicated -------------------------------
     duplicate_indiv_ids <- reactive({
       check_indiv_ids_dup(indiv())
     })


### PR DESCRIPTION
Closes #49. Checks each uploaded file for empty columns and reports them as warnings.