### PR TITLE
Add link annotation app

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -117,6 +117,10 @@ app_server <- function(input, output, session) {
             "To read more about the correct format of a manifest, see this",
             HTML("<a href=\"https://docs.synapse.org/articles/uploading_in_bulk.html\">documentation</a>.")
           ),
+          p(
+            "To explore accepted annotation keys and values, refer to the",
+            HTML("<a href=\"https://shinypro.synapse.org/users/nsanati/annotationUI/\">annoation application</a>.")
+          ),
           p("Note you must be logged in to Synapse for this application to work."),
           # nolint end
           easyClose = TRUE

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -119,7 +119,7 @@ app_server <- function(input, output, session) {
           ),
           p(
             "To explore accepted annotation keys and values, refer to the",
-            HTML("<a href=\"https://shinypro.synapse.org/users/nsanati/annotationUI/\">annoation application</a>.")
+            HTML("<a href=\"https://shinypro.synapse.org/users/nsanati/annotationUI/\">annotation application</a>.")
           ),
           p("Note you must be logged in to Synapse for this application to work."),
           # nolint end

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -119,7 +119,7 @@ app_server <- function(input, output, session) {
           ),
           p(
             "To explore accepted annotation keys and values, refer to the",
-            HTML("<a target=\"_blank\" href=\"https://shinypro.synapse.org/users/nsanati/annotationUI/\">annotation application</a>.")
+            HTML("<a target=\"_blank\" href=\"https://shinypro.synapse.org/users/nsanati/annotationUI/\">annotation dictionary</a>.")
           ),
           p("Note you must be logged in to Synapse for this application to work."),
           # nolint end

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -115,7 +115,7 @@ app_server <- function(input, output, session) {
           p("Upload .csv files of your individual, biospecimen, and assay metadata, and upload your manifest as a .tsv or .txt file. The app will check your data for common errors in the metadata and ensure that there are no missing specimen IDs between the metadata and the data files listed in the manifest."),
           p(
             "To read more about the correct format of a manifest, see this",
-            HTML("<a href=\"https://docs.synapse.org/articles/uploading_in_bulk.html\">documentation</a>.")
+            HTML("<a target=\"_blank\" href=\"https://docs.synapse.org/articles/uploading_in_bulk.html\">documentation</a>.")
           ),
           p(
             "To explore accepted annotation keys and values, refer to the",

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -119,7 +119,7 @@ app_server <- function(input, output, session) {
           ),
           p(
             "To explore accepted annotation keys and values, refer to the",
-            HTML("<a href=\"https://shinypro.synapse.org/users/nsanati/annotationUI/\">annotation application</a>.")
+            HTML("<a target=\"_blank\" href=\"https://shinypro.synapse.org/users/nsanati/annotationUI/\">annotation application</a>.")
           ),
           p("Note you must be logged in to Synapse for this application to work."),
           # nolint end

--- a/R/check-annotation-keys.R
+++ b/R/check-annotation-keys.R
@@ -170,7 +170,7 @@ check_keys <- function(x, annotations, whitelist_keys = NULL,
     ## If return_valid is FALSE, return condition object
     keys <- setdiff(x, annotations$key)
     keys <- setdiff(keys, whitelist_keys)
-    behavior <- "All annotation keys should conform to the vocabulary. Refer to the <a target=\"_blank\" href=\"https://shinypro.synapse.org/users/nsanati/annotationUI/\">annotation application</a> for accepted keys." # nolint
+    behavior <- "All annotation keys should conform to the vocabulary. Refer to the <a target=\"_blank\" href=\"https://shinypro.synapse.org/users/nsanati/annotationUI/\">annotation dictionary</a> for accepted keys." # nolint
     
     if (length(keys) == 0) {
       check_pass(

--- a/R/check-annotation-keys.R
+++ b/R/check-annotation-keys.R
@@ -170,7 +170,7 @@ check_keys <- function(x, annotations, whitelist_keys = NULL,
     ## If return_valid is FALSE, return condition object
     keys <- setdiff(x, annotations$key)
     keys <- setdiff(keys, whitelist_keys)
-    behavior <- "All annotation keys should conform to the vocabulary. Refer to the annotation application for accepted keys." # nolint
+    behavior <- "All annotation keys should conform to the vocabulary. Refer to the <a target=\"_blank\" href=\"https://shinypro.synapse.org/users/nsanati/annotationUI/\">annotation application</a> for accepted keys." # nolint
     
     if (length(keys) == 0) {
       check_pass(

--- a/R/check-annotation-keys.R
+++ b/R/check-annotation-keys.R
@@ -170,15 +170,17 @@ check_keys <- function(x, annotations, whitelist_keys = NULL,
     ## If return_valid is FALSE, return condition object
     keys <- setdiff(x, annotations$key)
     keys <- setdiff(keys, whitelist_keys)
+    behavior <- "All annotation keys should conform to the vocabulary. Refer to the annotation application for accepted keys." # nolint
+    
     if (length(keys) == 0) {
       check_pass(
         msg = success_msg,
-        behavior = "All annotation keys should conform to the vocabulary"
+        behavior = behavior
       )
     } else {
       check_fail(
         msg = fail_msg,
-        behavior = "All annotation keys should conform to the vocabulary",
+        behavior = behavior,
         data = keys
       )
     }

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -292,15 +292,16 @@ check_values <- function(x, annotations, whitelist_keys = NULL,
   if (isTRUE(return_valid)) {
     return(values)
   }
+  behavior <- "All annotation keys should conform to the vocabulary. Refer to the annotation application for accepted keys." # nolint
   if (length(values) == 0) {
     check_pass(
       msg = success_msg,
-      behavior = "All annotation values should conform to the vocabulary"
+      behavior = behavior
     )
   } else {
     check_fail(
       msg = fail_msg,
-      behavior = "All annotation values should conform to the vocabulary",
+      behavior = behavior,
       data = values
     )
   }

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -292,7 +292,7 @@ check_values <- function(x, annotations, whitelist_keys = NULL,
   if (isTRUE(return_valid)) {
     return(values)
   }
-  behavior <- "All annotation values should conform to the vocabulary. Refer to the <a target=\"_blank\" href=\"https://shinypro.synapse.org/users/nsanati/annotationUI/\">annotation application</a> for accepted values." # nolint
+  behavior <- "All annotation values should conform to the vocabulary. Refer to the <a target=\"_blank\" href=\"https://shinypro.synapse.org/users/nsanati/annotationUI/\">annotation dictionary</a> for accepted values." # nolint
   if (length(values) == 0) {
     check_pass(
       msg = success_msg,

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -292,7 +292,7 @@ check_values <- function(x, annotations, whitelist_keys = NULL,
   if (isTRUE(return_valid)) {
     return(values)
   }
-  behavior <- "All annotation values should conform to the vocabulary. Refer to the annotation application for accepted values." # nolint
+  behavior <- "All annotation values should conform to the vocabulary. Refer to the <a target=\"_blank\" href=\"https://shinypro.synapse.org/users/nsanati/annotationUI/\">annotation application</a> for accepted values." # nolint
   if (length(values) == 0) {
     check_pass(
       msg = success_msg,

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -292,7 +292,7 @@ check_values <- function(x, annotations, whitelist_keys = NULL,
   if (isTRUE(return_valid)) {
     return(values)
   }
-  behavior <- "All annotation keys should conform to the vocabulary. Refer to the annotation application for accepted keys." # nolint
+  behavior <- "All annotation values should conform to the vocabulary. Refer to the annotation application for accepted values." # nolint
   if (length(values) == 0) {
     check_pass(
       msg = success_msg,


### PR DESCRIPTION
Fixes #71.
Changed the behavior in annotation key/value checks to be a reused variable. 
Added links to annotation app to instructions and behaviors for key/value annotation check_fail and check_pass. Made annotation app links and documentation link open in new tabs.