### PR TITLE
Changed manifest requirements to template

### DIFF
--- a/R/check-col-names.R
+++ b/R/check-col-names.R
@@ -28,6 +28,8 @@ check_col_names <- function(data, template, success_msg = NULL, fail_msg = NULL,
 #' @rdname check_col_names
 #' @examples
 #' \dontrun{
+#' library("synapser")
+#' synLogin()
 #' a <- data.frame(path = "/path/file.txt", parent = "syn123", assay = "rnaSeq")
 #' check_cols_manifest(a)
 #'

--- a/R/check-col-names.R
+++ b/R/check-col-names.R
@@ -27,12 +27,13 @@ check_col_names <- function(data, template, success_msg = NULL, fail_msg = NULL,
 #' @export
 #' @rdname check_col_names
 #' @examples
-#'
+#' \dontrun{
 #' a <- data.frame(path = "/path/file.txt", parent = "syn123", assay = "rnaSeq")
 #' check_cols_manifest(a)
 #'
 #' b <- data.frame(assay = "rnaSeq")
 #' check_cols_manifest(b)
+#' }
 check_cols_manifest <- function(data,
                                 success_msg = "All manifest columns present",
                                 fail_msg = "Missing columns in the manifest",

--- a/R/check-col-names.R
+++ b/R/check-col-names.R
@@ -40,7 +40,8 @@ check_cols_manifest <- function(data,
   if (is.null(data)) {
     return(NULL)
   }
-  required <- c("path", "parent")
+  id <- "syn20820080"
+  required <- get_template(id, ...)
   behavior <- paste0(
     "Manifest should contain columns: ",
     paste(required, collapse = ", ")

--- a/tests/testthat/test-check-col-names.R
+++ b/tests/testthat/test-check-col-names.R
@@ -150,12 +150,12 @@ test_that("check_cols_assay returns invalid columns within condition object", {
 })
 
 test_that("check_cols_manifest works for manifest columns", {
-  cols <- c("path", "parent", "name")
+  cols <- get_template("syn20820080", version = 3)
   dat <- data.frame(matrix(ncol = length(cols)))
   names(dat) <- cols
-  incomplete <- data.frame(path = "/home/file.txt") # nolint
+  incomplete <- dat[, !names(dat) %in% "parent"]
 
-  expect_true(inherits(check_cols_manifest(dat), "check_pass"))
+  expect_true(inherits(check_cols_manifest(dat, version = 3), "check_pass"))
   expect_equal(check_cols_manifest(incomplete)$data, "parent")
 })
 


### PR DESCRIPTION
Fixes #76 
Changed the required manifest annotations to be in the form of a template. Added manifest template id.