### PR TITLE
Ensure check_value extracts annotation values as a vector even when input is a tibble

### DIFF
--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -223,7 +223,7 @@ check_value <- function(values, key, annotations, whitelist_keys = NULL,
   if (!key %in% annotations$key) {
     return(NULL)
   }
-  annot_values <- annotations[annotations$key == key, "value"]
+  annot_values <- annotations[annotations$key == key, ]$value
   ## If key is being whitelisted, treat all values as valid
   if (key %in% whitelist_keys) {
     if (isTRUE(return_valid)) {

--- a/tests/testthat/test-check-annotation-values.R
+++ b/tests/testthat/test-check-annotation-values.R
@@ -131,6 +131,16 @@ test_that("check_value checks column type when no enumerated values", {
   )
 })
 
+test_that("check_value works with a tibble of multiple values", {
+  annots <- tribble(
+    ~key, ~value, ~columnType,
+    "fileFormat", "txt", "STRING",
+    "fileFormat", "csv", "STRING",
+    "species", "Human", "STRING"
+  )
+  res <- check_value(values = "txt", key = "fileFormat", annotations = annots)
+  expect_equal(res, character(0))
+})
 
 ## check_values() --------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #79 