### PR TITLE
Prevent crashes when user isn't in correct team

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
     rlang,
     shiny,
     shinydashboard,
+    shinyjs,
     skimr,
     stats,
     synapser,

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -22,15 +22,25 @@ app_server <- function(input, output, session) {
     membership <- check_team_membership(teams = c("3320424"), user = user)
     report_missing_membership(membership)
 
-    ## Create folder for upload (wrapped in try() to prevent app crashing when a
-    ## non-member of the team uses it, because otherwise the modal telling
-    ## people how to join isn't clickable)
-    created_folder <- try(
-      create_folder(
-        parent = "syn20506363",
-        name = user$userName
+    ## If user is a member of the team(s), create folder to save files and
+    ## enable inputs
+    if (inherits(membership, "check_pass")) {
+      created_folder <- try(
+        create_folder(
+          parent = "syn20506363",
+          name = user$userName
+        )
       )
-    )
+      inputs_to_enable <- c(
+        "indiv_meta",
+        "biosp_meta",
+        "assay_meta",
+        "manifest",
+        "species",
+        "assay_name"
+      )
+      purrr::walk(inputs_to_enable, function(x) shinyjs::enable(x))
+    }
 
     ## Download annotation definitions
     annots <- get_synapse_annotations()

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -22,10 +22,14 @@ app_server <- function(input, output, session) {
     membership <- check_team_membership(teams = c("3320424"), user = user)
     report_missing_membership(membership)
 
-    ## Create folder for upload
-    created_folder <- create_folder(
-      parent = "syn20506363",
-      name = user$userName
+    ## Create folder for upload (wrapped in try() to prevent app crashing when a
+    ## non-member of the team uses it, because otherwise the modal telling
+    ## people how to join isn't clickable)
+    created_folder <- try(
+      create_folder(
+        parent = "syn20506363",
+        name = user$userName
+      )
     )
 
     ## Download annotation definitions

--- a/R/app-ui.R
+++ b/R/app-ui.R
@@ -9,6 +9,9 @@ app_ui <- function(request) {
       # Add resources in www
       golem_add_external_resources(),
 
+      # Use shinyjs
+      shinyjs::useShinyjs(),
+
       # Sidebar
       sidebarLayout(
         sidebarPanel(
@@ -17,51 +20,63 @@ app_ui <- function(request) {
           br(),
 
           # Files to be validated
-          fileInput(
-            "indiv_meta",
-            "Individual metadata file (.csv)",
-            width = NULL,
-            accept = c(
-              "text/csv",
-              "text/comma-separated-values,text/plain",
-              ".csv"
+          shinyjs::disabled(
+            fileInput(
+              "indiv_meta",
+              "Individual metadata file (.csv)",
+              width = NULL,
+              accept = c(
+                "text/csv",
+                "text/comma-separated-values,text/plain",
+                ".csv"
+              )
             )
           ),
 
-          fileInput(
-            "biosp_meta",
-            "Biospecimen metadata file (.csv)",
-            width = NULL,
-            accept = c(
-              "text/csv",
-              "text/comma-separated-values,text/plain",
-              ".csv"
+          shinyjs::disabled(
+            fileInput(
+              "biosp_meta",
+              "Biospecimen metadata file (.csv)",
+              width = NULL,
+              accept = c(
+                "text/csv",
+                "text/comma-separated-values,text/plain",
+                ".csv"
+              )
             )
           ),
 
-          fileInput(
-            "assay_meta",
-            "Assay metadata file (.csv)",
-            width = NULL,
-            accept = c(
-              "text/csv",
-              "text/comma-separated-values,text/plain",
-              ".csv"
+          shinyjs::disabled(
+            fileInput(
+              "assay_meta",
+              "Assay metadata file (.csv)",
+              width = NULL,
+              accept = c(
+                "text/csv",
+                "text/comma-separated-values,text/plain",
+                ".csv"
+              )
             )
           ),
 
-          radioButtons("species", "Species", c("animal", "human")),
+          shinyjs::disabled(
+            radioButtons("species", "Species", c("animal", "human"))
+          ),
 
-          selectInput("assay_name", "Assay type", c("rnaSeq", "proteomics")),
+          shinyjs::disabled(
+            selectInput("assay_name", "Assay type", c("rnaSeq", "proteomics"))
+          ),
 
-          fileInput(
-            "manifest",
-            "Upload Manifest File (.tsv or .txt)",
-            multiple = FALSE,
-            accept = c(
-              "text/tsv",
-              "text/tab-separated-values,text/plain",
-              ".tsv"
+          shinyjs::disabled(
+            fileInput(
+              "manifest",
+              "Upload Manifest File (.tsv or .txt)",
+              multiple = FALSE,
+              accept = c(
+                "text/tsv",
+                "text/tab-separated-values,text/plain",
+                ".tsv"
+              )
             )
           )
         ),
@@ -132,7 +147,6 @@ app_ui <- function(request) {
 
 #' @import shiny
 golem_add_external_resources <- function() {
-
   addResourcePath(
     "www", system.file("app/www", package = "dccvalidator")
   )


### PR DESCRIPTION
Fixes #86. Alters the app to:
* Only create a folder for saving stuff if the user is in the correct team
* Disable inputs on startup, and enable them only once the app has established that the user is a member of the team. This will prevent errors if the user is logged in but not a member of the team by preventing users from uploading data that would then fail to upload due to the lack of permissions.

This comes with the tradeoff that users who _are_ logged in and _are_ in the correct team will experience a slight delay when they first load the app. It takes a noticeable amount of time for the app to recognize that they have access and enable the inputs. @kelshmo @Aryllen if you have time would you be able to try testing this out locally (or I can demo for you) and let me know if you think that's too much friction for the logged in user? The alternative is to keep inputs enabled on startup, and only disable them if they're not a member of the team. The disadvantage to that is the non-logged-in user would still have the options enabled.