### PR TITLE
Allow checking IDs in only one direction

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -165,7 +165,13 @@ app_server <- function(input, output, session) {
       check_specimen_ids_match(biosp(), assay(), "biospecimen", "assay")
     })
     specimen_ids_biosp_manifest <- reactive({
-      check_specimen_ids_match(biosp(), manifest(), "biospecimen", "manifest")
+      check_specimen_ids_match(
+        biosp(),
+        manifest(),
+        "biospecimen",
+        "manifest",
+        bidirectional = FALSE
+      )
     })
 
     # Annotation keys in manifest are valid ------------------------------------

--- a/R/check-ids-match.R
+++ b/R/check-ids-match.R
@@ -113,8 +113,9 @@ check_ids_match <- function(x, y, idcol = c("individualID", "specimenID"),
 #' a <- data.frame(individualID = LETTERS[1:3])
 #' b <- data.frame(individualID = LETTERS[1:4])
 #' check_specimen_ids_match(a, b, "individual", "biospecimen")
-check_indiv_ids_match <- function(x, y, xname = NULL, yname = NULL) {
-  check_ids_match(x, y, "individualID", xname, yname)
+check_indiv_ids_match <- function(x, y, xname = NULL, yname = NULL,
+                                  bidirectional = TRUE) {
+  check_ids_match(x, y, "individualID", xname, yname, bidirectional)
 }
 
 #' Check specimen IDs
@@ -128,6 +129,7 @@ check_indiv_ids_match <- function(x, y, xname = NULL, yname = NULL) {
 #' a <- data.frame(specimenID = LETTERS[1:3])
 #' b <- data.frame(specimenID = LETTERS[1:4])
 #' check_specimen_ids_match(a, b, "biospecimen", "assay")
-check_specimen_ids_match <- function(x, y, xname = NULL, yname = NULL) {
-  check_ids_match(x, y, "specimenID", xname, yname)
+check_specimen_ids_match <- function(x, y, xname = NULL, yname = NULL,
+                                     bidirectional = TRUE) {
+  check_ids_match(x, y, "specimenID", xname, yname, bidirectional)
 }

--- a/R/check-ids-match.R
+++ b/R/check-ids-match.R
@@ -5,12 +5,15 @@
 #' @param x,y Data frames to compare
 #' @param idcol Name of column containing ids to compare
 #' @param xname,yname Names of x and y (to be used in resulting messages)
+#' @param bidirectional Should mismatches from both x and y be reported?
+#'   Defaults to `TRUE`; if `FALSE`, will return only IDs in `y` that are not
+#'   present in `x` (IDs in `x` but not `y` will be ignored).
 #' @return A condition object indicating whether IDs match (`"check_pass"`) or
 #'   not (`"check_fail"`). Mismatched IDs are included as data within the
 #'   object.
 #' @export
 check_ids_match <- function(x, y, idcol = c("individualID", "specimenID"),
-                            xname = NULL, yname = NULL) {
+                            xname = NULL, yname = NULL, bidirectional = TRUE) {
   if (is.null(x) | is.null(y)) {
     return(NULL)
   }
@@ -65,7 +68,8 @@ check_ids_match <- function(x, y, idcol = c("individualID", "specimenID"),
   }
 
   ## If nothing is missing, return check_pass
-  if (length(missing_from_x) == 0 & length(missing_from_y) == 0) {
+  if ((length(missing_from_x) == 0 & length(missing_from_y) == 0) |
+    (bidirectional == FALSE & length(missing_from_x) == 0)) {
     check_pass(
       msg = paste0(
         "All ",

--- a/R/check-ids-match.R
+++ b/R/check-ids-match.R
@@ -56,6 +56,9 @@ check_ids_match <- function(x, y, idcol = c("individualID", "specimenID"),
   ## otherwise gives a more generic message.
   if (is.null(xname) | is.null(yname)) {
     behavior <- paste0(idcol, " values should match.")
+    ## Give them generic names to be included in the check_fail data if needed
+    xname <- xname %||% "x"
+    yname <- yname %||% "y"
   } else {
     behavior <- paste0(
       idcol,

--- a/R/utils.R
+++ b/R/utils.R
@@ -36,3 +36,7 @@ save_to_synapse <- function(input_file, parent, name = NULL) {
   )
   synapser::synStore(file_to_upload)
 }
+
+"%||%" <- function(a, b) {
+  if (!is.null(a)) a else b
+}

--- a/man/check_ids_match.Rd
+++ b/man/check_ids_match.Rd
@@ -9,9 +9,11 @@
 check_ids_match(x, y, idcol = c("individualID", "specimenID"),
   xname = NULL, yname = NULL, bidirectional = TRUE)
 
-check_indiv_ids_match(x, y, xname = NULL, yname = NULL)
+check_indiv_ids_match(x, y, xname = NULL, yname = NULL,
+  bidirectional = TRUE)
 
-check_specimen_ids_match(x, y, xname = NULL, yname = NULL)
+check_specimen_ids_match(x, y, xname = NULL, yname = NULL,
+  bidirectional = TRUE)
 }
 \arguments{
 \item{x, y}{Data frames to compare}

--- a/man/check_ids_match.Rd
+++ b/man/check_ids_match.Rd
@@ -7,7 +7,7 @@
 \title{Check ids}
 \usage{
 check_ids_match(x, y, idcol = c("individualID", "specimenID"),
-  xname = NULL, yname = NULL)
+  xname = NULL, yname = NULL, bidirectional = TRUE)
 
 check_indiv_ids_match(x, y, xname = NULL, yname = NULL)
 
@@ -19,6 +19,10 @@ check_specimen_ids_match(x, y, xname = NULL, yname = NULL)
 \item{idcol}{Name of column containing ids to compare}
 
 \item{xname, yname}{Names of x and y (to be used in resulting messages)}
+
+\item{bidirectional}{Should mismatches from both x and y be reported?
+Defaults to \code{TRUE}; if \code{FALSE}, will return only IDs in \code{y} that are not
+present in \code{x} (IDs in \code{x} but not \code{y} will be ignored).}
 }
 \value{
 A condition object indicating whether IDs match (\code{"check_pass"}) or

--- a/tests/testthat/test-check-ids-match.R
+++ b/tests/testthat/test-check-ids-match.R
@@ -144,3 +144,23 @@ test_that("check_ids_match handles NULL input", {
   expect_null(check_ids_match(dat, NULL, "individualID"))
   expect_null(check_ids_match(NULL, NULL, "individualID"))
 })
+
+test_that("check_ids_match bidirectional arg looks only in one direction", {
+  meta <- data.frame(individualID = 1:4)
+  manifest <- data.frame(individualID = 1:2)
+  res1 <- check_ids_match(
+    meta,
+    manifest,
+    idcol = "individualID",
+    bidirectional = FALSE
+  )
+  res2 <- check_ids_match(
+    manifest,
+    meta,
+    idcol = "individualID",
+    bidirectional = FALSE
+  )
+  expect_true(inherits(res1, "check_pass"))
+  expect_true(inherits(res2, "check_fail"))
+  expect_equal(res2$data[[1]], c(3, 4))
+})

--- a/tests/testthat/test-check-ids-match.R
+++ b/tests/testthat/test-check-ids-match.R
@@ -164,3 +164,10 @@ test_that("check_ids_match bidirectional arg looks only in one direction", {
   expect_true(inherits(res2, "check_fail"))
   expect_equal(res2$data[[1]], c(3, 4))
 })
+
+test_that("check_ids_match data gets default names if not provided", {
+  x <- data.frame(individualID = 1:3)
+  y <- data.frame(individualID = 4:6)
+  res <- check_ids_match(x, y, idcol = "individualID")
+  expect_equal(names(res$data), c("Missing from x", "Missing from y"))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -25,3 +25,21 @@ test_that("get_annotation gets value of an annotation on a Synapse entity", {
   annot <- get_annotation("syn17038064", "fileFormat")
   expect_equal(annot, c(syn17038064 = "txt"))
 })
+
+test_that("%||% gives b if a is NULL", {
+  a <- NULL
+  b <- "foo"
+  expect_equal(a %||% b, "foo")
+
+  a <- "bar"
+  b <- "baz"
+  expect_equal(a %||% b, "bar")
+
+  a <- NA
+  b <- "foo"
+  expect_equal(a %||% b, NA)
+
+  a <- NULL
+  b <- NULL
+  expect_null(a %||% b)
+})


### PR DESCRIPTION
Fixes #85. This adds a `bidirectional` argument to `check_ids_match()` that defaults to `TRUE` (will check mismatches between the IDs in both directions) but can be set to `FALSE` in cases where we want to allow one set of IDs to be a superset of another (e.g. when someone is providing new data to an existing study and the manifest has fewer IDs than the comprehensive metadata).

The app now checks with `bidirectional = FALSE` when checking specimen IDs between the biospecimen file and manifest. If the manifest has specimen IDs that are missing from the biospecimen file, the check will fail; if the biospecimen file has IDs that are missing from the manifest, that's fine. One question I have is that in this case, the success message is the same as if the IDs were completely matching ("All specimenID values match between biospecimen and manifest") -- is that confusing, or fine?