### PR TITLE
Give test folder a timestamped name

### DIFF
--- a/tests/testthat/test-create-folder.R
+++ b/tests/testthat/test-create-folder.R
@@ -6,9 +6,17 @@ attempt_login()
 test_that("create_folder() creates a folder", {
   skip_if_not(logged_in())
 
+  op <- options(digits.secs = 3)
+  ## Create folder name with timestamp including milliseconds
+  name <- paste(
+    "my_test_folder",
+    format(Sys.time(), "%Y-%m-%d_%H.%M.%OS"),
+    sep = "_"
+  )
+  options(op) # reset digits options
   created_folder <- create_folder(
     parent = "syn17038062",
-    name = "my_test_folder"
+    name = name
   )
   expect_true(inherits(created_folder, "Folder"))
   on.exit(synDelete(created_folder)) # delete on exit


### PR DESCRIPTION
Hoping this will fix #100 but we'll have to wait and see to be sure. I'm not totally sure what has been causing these errors, but my hunch is that if multiple builds are running at roughly the same time they were interfering with the same folder. I can't force an error locally, however. 
