### PR TITLE
Move covr::codecov() to after_success in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,12 @@ jobs:
         - |
           R CMD INSTALL $PKG_TARBALL
           Rscript -e 'lintr::lint_package()'
-          Rscript -e 'covr::codecov()'
 
 r_github_packages:
   - jimhester/lintr
+
+after_success:
+  - Rscript -e 'covr::codecov()'
 
 env:
   global:


### PR DESCRIPTION
Currently it will only run on pull request builds, and I'd prefer it run on push builds as well.