### PR TITLE
Upgrade renv version

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -730,15 +730,14 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "0.7.0-125",
+      "Version": "0.7.1-16",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "rstudio",
       "RemoteRepo": "renv",
       "RemoteRef": "master",
-      "RemoteSha": "c6b89be02de6371dad6f778250ce230dc776eaf1",
-      "Hash": "95a465dc04f509349cd22a63c3e45344"
+      "RemoteSha": "5d0c0def33d07b04b95f1134ecbbbf7cd551c7f8"
     },
     "reshape2": {
       "Package": "reshape2",

--- a/renv/.gitignore
+++ b/renv/.gitignore
@@ -1,2 +1,3 @@
 library/
 python/
+staging/

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,7 +2,7 @@
 local({
 
   # the requested version of renv
-  version <- "0.7.0-125"
+  version <- "0.7.1-16"
 
   # avoid recursion
   if (!is.na(Sys.getenv("RENV_R_INITIALIZING", unset = NA)))


### PR DESCRIPTION
@Aryllen this might help you use renv locally, since the latest version should have the changes that help reduce the length of the path of the PythonEmbedInR install.