### PR TITLE
Fix assay template bug

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -153,7 +153,7 @@ app_server <- function(input, output, session) {
       input$species
     })
     assay_name <- reactive({
-      input$assay
+      input$assay_name
     })
 
     observeEvent(input$instructions, {


### PR DESCRIPTION
Fixes #112. 

Input for the assay type was called `assay_name` in app_ui, but app_server was looking for `input$assay`.