### PR TITLE
Allow coercing integers to numeric

### DIFF
--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -3,12 +3,19 @@
 #' Checks that all annotation values are valid. It does not report on values for
 #' invalid _keys_; see [check_annotation_keys()].
 #'
+#' If the allowable annotation values are an enumerated list,
+#' `check_annotation_values()` compares the values in the data to the values in
+#' this list. If there is no enumerated list of values and the annotation
+#' definition merely specifies a required type, then the values are checked
+#' against that type, with values that are coercible to the correct type treated
+#' as valid (see [can_coerce()]).
+#'
 #' @inheritParams check_annotation_keys
 #' @param ... Additional options to [`check_values()`]
 #' @return A condition object indicating whether all annotation values are
 #'   valid. Invalid annotation values are included as data within the object.
 #' @export
-#' @seealso [valid_annotation_values()]
+#' @seealso [valid_annotation_values()], [can_coerce()]
 #'
 #' @examples
 #' \dontrun{
@@ -178,6 +185,7 @@ valid_annotation_values.CsvFileTable <- function(x, annotations, ...) {
 #' @return A vector of invalid values (if `return_valid = FALSE`; otherwise a
 #'   vector of valid values).
 #' @rdname check_values
+#' @seealso [can_coerce()]
 check_type <- function(values, key, annotations, whitelist_values = NULL,
                        return_valid = FALSE) {
   coltype <- annotations[annotations$key == key, "columnType"]
@@ -225,6 +233,9 @@ check_type <- function(values, key, annotations, whitelist_values = NULL,
 #' read lengths, pH values, etc., which are defined as strings in our annotation
 #' vocabulary but can reasonably be numbers.
 #'
+#' This function will also return `TRUE` if the values are integers and the
+#' desired class is numeric.
+#'
 #' This function will *not* affect validation of enumerated values, regardless
 #' of their class. It is only used by the [check_type()] function, which
 #' validates annotations that have a required type but no enumerated values.
@@ -233,10 +244,27 @@ check_type <- function(values, key, annotations, whitelist_values = NULL,
 #' @param class Class of interest
 #' @return Boolean value; TRUE if `values` are coercible to `class`, `FALSE`
 #'   otherwise.
+#' @seealso [check_annotation_values()], [check_type()]
+#' @examples
+#' # Not run because function is not exported
+#' \dontrun{
+#' # Coercible:
+#' can_coerce(1, "character")
+#' can_coerce(TRUE, "character")
+#' can_coerce(1L, "character")
+#' can_coerce(1L, "numeric")
+#'
+#' # Not coercible:
+#' can_coerce("foo", "numeric")
+#' can_coerce("foo", "logical")
+#' can_coerce(2.5, "integer")
+#' }
 can_coerce <- function(values, class) {
   if (class == "character" &
     (inherits(values, "numeric") | inherits(values, "integer") |
       inherits(values, "logical"))) {
+    return(TRUE)
+  } else if (class == "numeric" & inherits(values, "integer")) {
     return(TRUE)
   } else {
     return(FALSE)

--- a/man/can_coerce.Rd
+++ b/man/can_coerce.Rd
@@ -27,7 +27,28 @@ This function is mainly in place so that we can automatically allow numeric
 read lengths, pH values, etc., which are defined as strings in our annotation
 vocabulary but can reasonably be numbers.
 
+This function will also return \code{TRUE} if the values are integers and the
+desired class is numeric.
+
 This function will \emph{not} affect validation of enumerated values, regardless
 of their class. It is only used by the \code{\link[=check_type]{check_type()}} function, which
 validates annotations that have a required type but no enumerated values.
+}
+\examples{
+# Not run because function is not exported
+\dontrun{
+# Coercible:
+can_coerce(1, "character")
+can_coerce(TRUE, "character")
+can_coerce(1L, "character")
+can_coerce(1L, "numeric")
+
+# Not coercible:
+can_coerce("foo", "numeric")
+can_coerce("foo", "logical")
+can_coerce(2.5, "integer")
+}
+}
+\seealso{
+\code{\link[=check_annotation_values]{check_annotation_values()}}, \code{\link[=check_type]{check_type()}}
 }

--- a/man/check_annotation_values.Rd
+++ b/man/check_annotation_values.Rd
@@ -22,6 +22,14 @@ valid. Invalid annotation values are included as data within the object.
 Checks that all annotation values are valid. It does not report on values for
 invalid \emph{keys}; see \code{\link[=check_annotation_keys]{check_annotation_keys()}}.
 }
+\details{
+If the allowable annotation values are an enumerated list,
+\code{check_annotation_values()} compares the values in the data to the values in
+this list. If there is no enumerated list of values and the annotation
+definition merely specifies a required type, then the values are checked
+against that type, with values that are coercible to the correct type treated
+as valid (see \code{\link[=can_coerce]{can_coerce()}}).
+}
 \examples{
 \dontrun{
 library("synapser")
@@ -53,5 +61,5 @@ check_annotation_values(dat, whitelist_values = list(assay = c("foo")))
 }
 }
 \seealso{
-\code{\link[=valid_annotation_values]{valid_annotation_values()}}
+\code{\link[=valid_annotation_values]{valid_annotation_values()}}, \code{\link[=can_coerce]{can_coerce()}}
 }

--- a/man/check_values.Rd
+++ b/man/check_values.Rd
@@ -59,3 +59,6 @@ the annotations dictionary. This check is somewhat permissive in that values
 that are coercible to the type are also treated as valid (see
 \code{\link[=can_coerce]{can_coerce()}}).
 }
+\seealso{
+\code{\link[=can_coerce]{can_coerce()}}
+}

--- a/tests/testthat/test-check-annotation-values.R
+++ b/tests/testthat/test-check-annotation-values.R
@@ -410,7 +410,12 @@ test_that("can_coerce() returns TRUE for numeric/integer/boolean->character", {
   expect_true(can_coerce(TRUE, "character"))
 })
 
+test_that("can_coerce() returns TRUE for integer->numeric", {
+  expect_true(can_coerce(1L, "numeric"))
+})
+
 test_that("can_coerce() returns FALSE if values aren't coercible", {
   expect_false(can_coerce("a", "numeric"))
   expect_false(can_coerce("a", "logical"))
+  expect_false(can_coerce(2.1, "integer"))
 })


### PR DESCRIPTION
Fixes #118. Also adds some additional documentation of the behavior of `check_annotation_values()`.