### PR TITLE
Add check that `individualID`s match in the manifest

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -208,6 +208,15 @@ app_server <- function(input, output, session) {
     individual_ids_indiv_biosp <- reactive({
       check_indiv_ids_match(indiv(), biosp(), "individual", "biospecimen")
     })
+    individual_ids_indiv_manifest <- reactive({
+      check_indiv_ids_match(
+        indiv(),
+        manifest(),
+        "individual",
+        "manifest",
+        bidirectional = FALSE
+      )
+    })
     specimen_ids_biosp_assay <- reactive({
       check_specimen_ids_match(biosp(), assay(), "biospecimen", "assay")
     })
@@ -348,6 +357,7 @@ app_server <- function(input, output, session) {
         missing_cols_assay(),
         missing_cols_manifest(),
         individual_ids_indiv_biosp(),
+        individual_ids_indiv_manifest(),
         specimen_ids_biosp_assay(),
         specimen_ids_biosp_manifest(),
         annotation_keys_manifest(),


### PR DESCRIPTION
Added in the check to verify that the `individualID`s in the manifest match with those in the individual metadata. Put bidirectional as `FALSE` for now since we are not adding in the functionality to add to an existing study, yet; there may be ids in the manifest that are not in the current individual metadata set.