### PR TITLE
Fix details for unnamed list

### DIFF
--- a/R/app-reporting.R
+++ b/R/app-reporting.R
@@ -77,9 +77,9 @@ show_details.default <- function(x) {
 
 #' @rdname show_details
 show_details.list <- function(x) {
-  dat <- purrr::map2_dfr(names(x), x, function(y, z) {
-    tibble::tibble(key = y, value = paste0(z, collapse = ", "))
-  })
+  dat <- purrr::map_dfr(x, function(x) {
+    tibble::tibble(value = paste0(x, collapse = ", "))
+  }, .id = "key")
   renderTable(dat, colnames = FALSE)
 }
 

--- a/R/check-ids-match.R
+++ b/R/check-ids-match.R
@@ -27,7 +27,7 @@ check_ids_match <- function(x, y, idcol = c("individualID", "specimenID"),
         xname,
         " or ",
         yname,
-        " metadata."
+        " metadata"
       ),
       behavior = paste0(
         xname,
@@ -36,7 +36,10 @@ check_ids_match <- function(x, y, idcol = c("individualID", "specimenID"),
         " metadata should both contain a column called ",
         idcol
       ),
-      data = list(colnames(x), colnames(y))
+      data = setNames(
+        list(colnames(x), colnames(y)),
+        c(xname, yname)
+      )
     )
     return(failure)
   }


### PR DESCRIPTION
Fixes #130 by both adding names to the list returned by `check_ids_match()`, and also updating `show_details()` to work on an unnamed list in case other functions return unnamed lists in the future.