### PR TITLE
Use glue to simplify some messages

### DIFF
--- a/R/check-col-names.R
+++ b/R/check-col-names.R
@@ -45,9 +45,8 @@ check_cols_manifest <- function(data,
   }
   id <- "syn20820080"
   required <- get_template(id, ...)
-  behavior <- paste0(
-    "Manifest should contain columns: ",
-    paste(required, collapse = ", ")
+  behavior <- glue::glue(
+    "Manifest should contain columns: {glue::glue_collapse(required, sep = ', ')}" # nolint
   )
   check_col_names(
     data,
@@ -78,9 +77,8 @@ check_cols_individual <- function(data, template,
     general = "syn12973253"
   )
   required <- get_template(id, ...)
-  behavior <- paste0(
-    "Individual file should contain columns: ",
-    paste(required, collapse = ", ")
+  behavior <- glue::glue(
+    "Individual file should contain columns: {glue::glue_collapse(required, sep = ', ')}" # nolint
   )
   check_col_names(
     data,
@@ -111,9 +109,8 @@ check_cols_assay <- function(data, template,
     proteomics = "syn12973255"
   )
   required <- get_template(id, ...)
-  behavior <- paste0(
-    "Assay file should contain columns: ",
-    paste(required, collapse = ", ")
+  behavior <- glue::glue(
+    "Assay file should contain columns: {glue::glue_collapse(required, sep = ', ')}" # nolint
   )
   check_col_names(
     data,
@@ -145,9 +142,8 @@ check_cols_biospecimen <- function(data, template,
     drosophila = "syn20673251"
   )
   required <- get_template(id, ...)
-  behavior <- paste0(
-    "Biospecimen file should contain columns: ",
-    paste(required, collapse = ", ")
+  behavior <- glue::glue(
+    "Biospecimen file should contain columns: {glue::glue_collapse(required, sep = ', ')}" # nolint
   )
   check_col_names(
     data,

--- a/R/check-ids-match.R
+++ b/R/check-ids-match.R
@@ -30,7 +30,7 @@ check_ids_match <- function(x, y, idcol = c("individualID", "specimenID"),
       behavior = glue::glue(
         "{xname} and {yname} metadata should both contain a column called {idcol}" # nolint
       ),
-      data = setNames(
+      data = stats::setNames(
         list(colnames(x), colnames(y)),
         c(xname, yname)
       )

--- a/R/check-ids-match.R
+++ b/R/check-ids-match.R
@@ -59,7 +59,7 @@ check_ids_match <- function(x, y, idcol = c("individualID", "specimenID"),
     (bidirectional == FALSE & length(missing_from_x) == 0)) {
     check_pass(
       msg = glue::glue(
-        "All {idcol} values match between {xname} and {yname}.",
+        "All {idcol} values match between {xname} and {yname}"
       ),
       behavior = behavior
     )

--- a/R/check-ids-match.R
+++ b/R/check-ids-match.R
@@ -20,21 +20,9 @@ check_ids_match <- function(x, y, idcol = c("individualID", "specimenID"),
   idcol <- match.arg(idcol)
   if (!idcol %in% colnames(x) | !idcol %in% colnames(y)) {
     failure <- check_fail(
-      msg = paste0(
-        "Missing column ",
-        idcol,
-        " in ",
-        xname,
-        " or ",
-        yname,
-        " metadata"
-      ),
-      behavior = paste0(
-        xname,
-        " and ",
-        yname,
-        " metadata should both contain a column called ",
-        idcol
+      msg = glue::glue("Missing column {idcol} in {xname} or {yname} metadata"),
+      behavior = glue::glue(
+        "{xname} and {yname} metadata should both contain a column called {idcol}" # nolint
       ),
       data = setNames(
         list(colnames(x), colnames(y)),
@@ -58,18 +46,13 @@ check_ids_match <- function(x, y, idcol = c("individualID", "specimenID"),
   ## Message of correct behavior. Uses the names of the x and y data if present,
   ## otherwise gives a more generic message.
   if (is.null(xname) | is.null(yname)) {
-    behavior <- paste0(idcol, " values should match.")
     ## Give them generic names to be included in the check_fail data if needed
     xname <- xname %||% "x"
     yname <- yname %||% "y"
+    behavior <- glue::glue("{idcol} values should match.")
   } else {
-    behavior <- paste0(
-      idcol,
-      " values in the ",
-      xname,
-      " and ",
-      yname,
-      " metadata should match."
+    behavior <- glue::glue(
+      "{idcol} values in the {xname} and {yname} metadata should match."
     )
   }
 
@@ -77,29 +60,20 @@ check_ids_match <- function(x, y, idcol = c("individualID", "specimenID"),
   if ((length(missing_from_x) == 0 & length(missing_from_y) == 0) |
     (bidirectional == FALSE & length(missing_from_x) == 0)) {
     check_pass(
-      msg = paste0(
-        "All ",
-        idcol,
-        " values match between ",
-        xname,
-        " and ",
-        yname
+      msg = glue::glue(
+        "All {idcol} values match between {xname} and {yname}.",
       ),
       behavior = behavior
     )
   } else {
     check_fail(
-      msg = paste0(
-        idcol,
-        " values are mismatched between ",
-        xname,
-        " and ",
-        yname
+      msg = glue::glue(
+        "{idcol} values are mismatched between {xname} and {yname}"
       ),
       behavior = behavior,
       data = stats::setNames(
         list(missing_from_x, missing_from_y),
-        paste("Missing from", c(xname, yname))
+        glue::glue("Missing from {c(xname, yname)}")
       )
     )
   }

--- a/R/check-ids-match.R
+++ b/R/check-ids-match.R
@@ -18,6 +18,12 @@ check_ids_match <- function(x, y, idcol = c("individualID", "specimenID"),
     return(NULL)
   }
   idcol <- match.arg(idcol)
+  if (is.null(xname) | is.null(yname)) {
+    ## Give them generic names to be included in the check_fail data if needed
+    xname <- xname %||% "x"
+    yname <- yname %||% "y"
+  }
+
   if (!idcol %in% colnames(x) | !idcol %in% colnames(y)) {
     failure <- check_fail(
       msg = glue::glue("Missing column {idcol} in {xname} or {yname} metadata"),
@@ -43,18 +49,10 @@ check_ids_match <- function(x, y, idcol = c("individualID", "specimenID"),
   missing_from_x <- setdiff(y[[idcol]], x[[idcol]])
   missing_from_y <- setdiff(x[[idcol]], y[[idcol]])
 
-  ## Message of correct behavior. Uses the names of the x and y data if present,
-  ## otherwise gives a more generic message.
-  if (is.null(xname) | is.null(yname)) {
-    ## Give them generic names to be included in the check_fail data if needed
-    xname <- xname %||% "x"
-    yname <- yname %||% "y"
-    behavior <- glue::glue("{idcol} values should match.")
-  } else {
-    behavior <- glue::glue(
-      "{idcol} values in the {xname} and {yname} metadata should match."
-    )
-  }
+  ## Message of correct behavior
+  behavior <- glue::glue(
+    "{idcol} values in the {xname} and {yname} metadata should match."
+  )
 
   ## If nothing is missing, return check_pass
   if ((length(missing_from_x) == 0 & length(missing_from_y) == 0) |

--- a/R/get-user-teams.R
+++ b/R/get-user-teams.R
@@ -14,11 +14,7 @@
 #' }
 get_user_teams <- function(user) {
   user_teams <- synapser::synRestGET(
-    paste0(
-      "/user/",
-      user$ownerId,
-      "/team?limit=10000"
-    )
+    glue::glue("/user/{user$ownerId}/team?limit=10000")
   )$results
 
   purrr::map_chr(user_teams, function(x) x$id)

--- a/renv.lock
+++ b/renv.lock
@@ -4,7 +4,7 @@
     "Repositories": [
       {
         "Name": "CRAN",
-        "URL": "https://cran.rstudio.com/"
+        "URL": "https://cran.rstudio.com"
       },
       {
         "Name": "Sage",
@@ -32,7 +32,7 @@
       },
       {
         "Name": "CRAN",
-        "URL": "https://cran.rstudio.com/"
+        "URL": "https://cran.rstudio.com"
       },
       {
         "Name": "Sage",
@@ -362,15 +362,10 @@
     },
     "glue": {
       "Package": "glue",
-      "Version": "1.3.1.9000",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteRepo": "glue",
-      "RemoteUsername": "tidyverse",
-      "RemoteRef": "master",
-      "RemoteSha": "71eeddfa43763880ccc6afd9021553fd728b1821",
-      "Hash": "6e2845c5f2b1399a0a080f6b2ce66ad9"
+      "Version": "1.3.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e8436e647719b7c9d01409767cd88cc8"
     },
     "golem": {
       "Package": "golem",
@@ -721,12 +716,12 @@
       "Version": "2.1.0.9000",
       "Source": "GitHub",
       "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteRepo": "remotes",
       "RemoteUsername": "r-lib",
+      "RemoteRepo": "remotes",
       "RemoteRef": "master",
-      "RemoteSha": "2f1a0401c31e0a0576ae9e54c38aa11e023ce169",
-      "Hash": "78d6592ef867b8f700ce9dd0f7a719c7"
+      "RemoteSha": "5b3da5f852772159cc2a580888e10536a43e9199",
+      "RemoteHost": "api.github.com",
+      "Hash": "069684d2abbfb39c91d369dcc201559f"
     },
     "renv": {
       "Package": "renv",
@@ -737,7 +732,8 @@
       "RemoteUsername": "rstudio",
       "RemoteRepo": "renv",
       "RemoteRef": "master",
-      "RemoteSha": "5d0c0def33d07b04b95f1134ecbbbf7cd551c7f8"
+      "RemoteSha": "5d0c0def33d07b04b95f1134ecbbbf7cd551c7f8",
+      "Hash": "955c76d1f84265b54f3f1ec0ef098d0a"
     },
     "reshape2": {
       "Package": "reshape2",

--- a/tests/testthat/test-check-ids-match.R
+++ b/tests/testthat/test-check-ids-match.R
@@ -129,13 +129,16 @@ test_that("check_specimen_ids_match catches missing specimen IDs", {
   expect_equal(res$data, expected_result)
 })
 
-test_that("Behavior message leaves out xname/yname if not provided", {
+test_that("Behavior message uses 'x' and 'y' if not provided", {
   res <- check_ids_match(
     invalid_individual,
     invalid_biospecimen,
     idcol = "individualID"
   )
-  expect_equal(res$behavior, "individualID values should match.")
+  expect_equal(
+    res$behavior,
+    "individualID values in the x and y metadata should match."
+  )
 })
 
 test_that("check_ids_match handles NULL input", {

--- a/tests/testthat/test-check-ids-match.R
+++ b/tests/testthat/test-check-ids-match.R
@@ -72,29 +72,29 @@ test_that("check_ids_match converts factor columns to character", {
   factor_biospecimen$individualID <- as.factor(factor_biospecimen$individualID) # nolint
 
   char <- check_ids_match(
-    valid_individual,
-    valid_biospecimen,
-    "individualID",
-    "individual",
-    "biospecimen"
+    x = valid_individual,
+    y = valid_biospecimen,
+    idcol = "individualID",
+    xname = "individual",
+    yname = "biospecimen"
   )
   fact <- check_ids_match(
-    factor_individual,
-    factor_biospecimen,
-    "individualID",
-    "individual",
-    "biospecimen"
+    x = factor_individual,
+    y = factor_biospecimen,
+    idcol = "individualID",
+    xname = "individual",
+    yname = "biospecimen"
   )
   expect_equal(char, fact)
 })
 
 test_that("check_ids_match passes when IDs match", {
   res <- check_ids_match(
-    valid_individual,
-    valid_biospecimen,
-    "individualID",
-    "individual",
-    "biospecimen"
+    x = valid_individual,
+    y = valid_biospecimen,
+    idcol = "individualID",
+    xname = "individual",
+    yname = "biospecimen"
   )
   expect_true(inherits(res, "check_pass"))
 })
@@ -152,14 +152,14 @@ test_that("check_ids_match bidirectional arg looks only in one direction", {
   meta <- data.frame(individualID = 1:4)
   manifest <- data.frame(individualID = 1:2)
   res1 <- check_ids_match(
-    meta,
-    manifest,
+    x = meta,
+    y = manifest,
     idcol = "individualID",
     bidirectional = FALSE
   )
   res2 <- check_ids_match(
-    manifest,
-    meta,
+    x = manifest,
+    y = meta,
     idcol = "individualID",
     bidirectional = FALSE
   )


### PR DESCRIPTION
Replaces some instances of `paste()` with `glue::glue()` for more concise messages.