### PR TITLE
Add back species_name() reactive

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -172,6 +172,9 @@ app_server <- function(input, output, session) {
     assay_template <- reactive({
       config::get("templates")$assay_templates[[input$assay_name]]
     })
+    species_name <- reactive({
+      input$species
+    })
 
     observeEvent(input$instructions, {
       showModal(


### PR DESCRIPTION
It was removed in #123 because we're no longer using it to look up the metadata templates, but we need it to annotate on upload in #121. Fixes #138 