### PR TITLE
Fix NA and bidirectional issues in check_ids_match.

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -220,8 +220,8 @@ app_server <- function(input, output, session) {
     })
     individual_ids_indiv_manifest <- reactive({
       check_indiv_ids_match(
-        manifest(),
         indiv(),
+        manifest(),
         "individual",
         "manifest",
         bidirectional = FALSE
@@ -232,8 +232,8 @@ app_server <- function(input, output, session) {
     })
     specimen_ids_biosp_manifest <- reactive({
       check_specimen_ids_match(
-        manifest(),
         biosp(),
+        manifest(),
         "biospecimen",
         "manifest",
         bidirectional = FALSE

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -220,8 +220,8 @@ app_server <- function(input, output, session) {
     })
     individual_ids_indiv_manifest <- reactive({
       check_indiv_ids_match(
-        indiv(),
         manifest(),
+        indiv(),
         "individual",
         "manifest",
         bidirectional = FALSE
@@ -232,8 +232,8 @@ app_server <- function(input, output, session) {
     })
     specimen_ids_biosp_manifest <- reactive({
       check_specimen_ids_match(
-        biosp(),
         manifest(),
+        biosp(),
         "biospecimen",
         "manifest",
         bidirectional = FALSE

--- a/R/check-ids-match.R
+++ b/R/check-ids-match.R
@@ -46,8 +46,8 @@ check_ids_match <- function(x, y, idcol = c("individualID", "specimenID"),
     y[[idcol]] <- as.character(y[[idcol]])
   }
 
-  missing_from_x <- setdiff(y[[idcol]], x[[idcol]])
-  missing_from_y <- setdiff(x[[idcol]], y[[idcol]])
+  missing_from_x <- na.omit(setdiff(y[[idcol]], x[[idcol]]))
+  missing_from_y <- na.omit(setdiff(x[[idcol]], y[[idcol]]))
 
   ## Message of correct behavior
   behavior <- glue::glue(


### PR DESCRIPTION
Fixes #135.

First issue was that `NA` was considered an individualID or biospecimenID. The manifest will have some columns that are `NA` due to the metadata files. These should be considered okay. Additionally, if one ID column is simply incomplete in a biospecimen or individual file (i.e. has some `NA`), then it will be flagged by the incomplete required column check anyway.

Second issue was that the `bidirectional = FALSE` flag checks the second dataset against the first dataset. The original order was checking the manifest IDs to see if any were missing from the biospecimen/individual IDs. It now checks to see if any of the biospecimen/individual IDs are missing from the manifest, which is as intended. 