### PR TITLE
Force synapse link to open in new tab

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -26,7 +26,7 @@ app_server <- function(input, output, session) {
     showModal(
       modalDialog(
         title = "Not logged in",
-        HTML("You must log in to <a href=\"https://www.synapse.org/\">Synapse</a> to use this application. Please log in, and then refresh this page.") # nolint
+        HTML("You must log in to <a target=\"_blank\" href=\"https://www.synapse.org/\">Synapse</a> to use this application. Please log in, and then refresh this page.") # nolint
       )
     )
   })


### PR DESCRIPTION
Fixes #150.

This is low hanging fruit and should work fine. I can't test it locally without it being a hassle (i.e. deleting my local login credentials).