### PR TITLE
Reset `fileInput`s in documentation tab after upload

### DIFF
--- a/R/mod-upload-documentation.R
+++ b/R/mod-upload-documentation.R
@@ -162,6 +162,8 @@ upload_documents_server <- function(input, output, session,
             annotations = doc_annots()
           )
         })
+        shinyjs::reset("study_doc")
+        shinyjs::reset("assay_doc")
       })
     }
   })


### PR DESCRIPTION
Fixes #154.

I do like the idea of clearing the `fileInput` elements after the files have been uploaded, but only for the documentation. This is only a visual change; the reactive input variable for these is not reset and, from my understanding, cannot be without uploading a new file. So someone could upload files to the server, submit the files (which writes them to Synapse), and then still re-submit the same files, even though the `fileInput` boxes are now empty. While it would probably appear to be odd behavior (the button would react as if it were saving the files), it would also be an odd thing to do anyway.