### PR TITLE
Ensure alt text is alt text and not a caption

### DIFF
--- a/docs/articles/using-the-dccvalidator-app-amp-ad.html
+++ b/docs/articles/using-the-dccvalidator-app-amp-ad.html
@@ -128,10 +128,7 @@
 <div id="data-validation" class="section level2">
 <h2 class="hasAnchor">
 <a href="#data-validation" class="anchor"></a>Data validation</h2>
-<p>Each study in AMP-AD has accompanying <a href="https://adknowledgeportal.synapse.org/#/Explore/Studies?Study=syn8391648">documentation in the portal</a>. You can submit your documentation through the dccvalidator app on the Documentation page. There should be a study description for the whole study, and an assay description for each of the assays that was performed. These can be in a single file, or you can upload multiple files to the assay description section.</p>
-<div class="figure">
-<img src="../man/figures/amp-documentation.png" alt=""><p class="caption">A screenshot of a website with instructions on how to provide documentation of a study, and a space to upload documentation files</p>
-</div>
+<p>Each study in AMP-AD has accompanying <a href="https://adknowledgeportal.synapse.org/#/Explore/Studies?Study=syn8391648">documentation in the portal</a>. You can submit your documentation through the dccvalidator app on the Documentation page. There should be a study description for the whole study, and an assay description for each of the assays that was performed. These can be in a single file, or you can upload multiple files to the assay description section. <img src="../man/figures/amp-documentation.png" alt="A screenshot of a website with instructions on how to provide documentation of a study, and a space to upload documentation files"></p>
 <div id="validating-metadata" class="section level3">
 <h3 class="hasAnchor">
 <a href="#validating-metadata" class="anchor"></a>Validating metadata</h3>
@@ -147,10 +144,7 @@
 <div id="viewing-data-summary" class="section level3">
 <h3 class="hasAnchor">
 <a href="#viewing-data-summary" class="anchor"></a>Viewing data summary</h3>
-<p>We also provide a summary of the files you have uploaded, showing the number of individuals, specimens, and files. We visualize the data in each column by its data type to help spot unexpected missing values.</p>
-<div class="figure">
-<img src="../man/figures/amp-summary.png" alt=""><p class="caption">A screenshot showing a summary of several data files uploaded, including how many specimens, individuals, and data files were included, and a breakdown of the types of data in the file</p>
-</div>
+<p>We also provide a summary of the files you have uploaded, showing the number of individuals, specimens, and files. We visualize the data in each column by its data type to help spot unexpected missing values. <img src="../man/figures/amp-summary.png" alt="A screenshot showing a summary of several data files uploaded, including how many specimens, individuals, and data files were included, and a breakdown of the types of data in the file"></p>
 </div>
 </div>
 </div>

--- a/vignettes/using-the-dccvalidator-app-amp-ad.Rmd
+++ b/vignettes/using-the-dccvalidator-app-amp-ad.Rmd
@@ -64,7 +64,6 @@ Documentation page. There should be a study description for the whole study, and
 an assay description for each of the assays that was performed. These can be in
 a single file, or you can upload multiple files to the assay description
 section.
-
 ![A screenshot of a website with instructions on how to provide documentation of a study, and a space to upload documentation files](../man/figures/amp-documentation.png)
 
 ### Validating metadata
@@ -87,5 +86,4 @@ Examples of the types of checks we perform are:
 We also provide a summary of the files you have uploaded, showing the number of
 individuals, specimens, and files. We visualize the data in each column by its
 data type to help spot unexpected missing values.
-
 ![A screenshot showing a summary of several data files uploaded, including how many specimens, individuals, and data files were included, and a breakdown of the types of data in the file](../man/figures/amp-summary.png)


### PR DESCRIPTION
For some reason if images are in their own paragraph, the alt text (used for accessibility purposes) shows up as a caption.