### PR TITLE
Deploy pkgdown site with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ jobs:
         - |
           R CMD INSTALL $PKG_TARBALL
           Rscript -e 'lintr::lint_package()'
+    - stage: deploy
+      before_cache: Rscript -e 'remotes::install_cran("pkgdown")'
+      provider: script
+      script: Rscript -e 'pkgdown::deploy_site_github()'
+      skip_cleanup: true
 
 r_github_packages:
   - jimhester/lintr

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ jobs:
           Rscript -e 'lintr::lint_package()'
     - stage: deploy
       before_cache: Rscript -e 'remotes::install_cran("pkgdown")'
-      provider: script
-      script: Rscript -e 'pkgdown::deploy_site_github()'
-      skip_cleanup: true
+      deploy:
+        provider: script
+        script: Rscript -e 'pkgdown::deploy_site_github()'
+        skip_cleanup: true
 
 r_github_packages:
   - jimhester/lintr


### PR DESCRIPTION
Closes #177. I more or less followed the setup instructions [here](https://pkgdown.r-lib.org/reference/deploy_site_github.html), hopefully this works? After this is merged we'll need to update the github settings to serve the site from the gh-pages branch instead of from the docs/ folder on master.