### PR TITLE
Use bidirectional = FALSE for all ID checking

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Validate CNS Data and Metadata
-Version: 0.0.0.9007
+Version: 0.0.0.9008
 Authors@R: 
     c(person(given = "Kara",
              family = "Woo",

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -226,7 +226,13 @@ app_server <- function(input, output, session) {
 
     # Individual and specimen IDs match ----------------------------------------
     individual_ids_indiv_biosp <- reactive({
-      check_indiv_ids_match(indiv(), biosp(), "individual", "biospecimen")
+      check_indiv_ids_match(
+        indiv(),
+        biosp(),
+        "individual",
+        "biospecimen",
+        bidirectional = FALSE
+      )
     })
     individual_ids_indiv_manifest <- reactive({
       check_indiv_ids_match(
@@ -238,7 +244,13 @@ app_server <- function(input, output, session) {
       )
     })
     specimen_ids_biosp_assay <- reactive({
-      check_specimen_ids_match(biosp(), assay(), "biospecimen", "assay")
+      check_specimen_ids_match(
+        biosp(),
+        assay(),
+        "biospecimen",
+        "assay",
+        bidirectional = FALSE
+      )
     })
     specimen_ids_biosp_manifest <- reactive({
       check_specimen_ids_match(


### PR DESCRIPTION
Biospecimen file can have a subset of individuals (if some individuals in the study were only used in behavioral experiments which don't have specimens). Assay file can have a subset of specimens.