### PR TITLE
Update `check_empty_cols()` to ignore required columns.

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -303,6 +303,7 @@ app_server <- function(input, output, session) {
     empty_cols_manifest <- reactive({
       check_cols_empty(
         manifest(),
+        required_cols = config::get("complete_columns")$manifest,
         success_msg = "No columns are empty in the manifest",
         fail_msg = "Some columns are empty in the manifest"
       )
@@ -310,6 +311,7 @@ app_server <- function(input, output, session) {
     empty_cols_indiv <- reactive({
       check_cols_empty(
         indiv(),
+        required_cols = config::get("complete_columns")$individual,
         success_msg = "No columns are empty in the individual metadata",
         fail_msg = "Some columns are empty in the individual metadata"
       )
@@ -317,6 +319,7 @@ app_server <- function(input, output, session) {
     empty_cols_biosp <- reactive({
       check_cols_empty(
         biosp(),
+        required_cols = config::get("complete_columns")$biospecimen,
         success_msg = "No columns are empty in the biospecimen metadata",
         fail_msg = "Some columns are empty in the biospecimen metadata"
       )
@@ -324,6 +327,7 @@ app_server <- function(input, output, session) {
     empty_cols_assay <- reactive({
       check_cols_empty(
         assay(),
+        required_cols = config::get("complete_columns")$assay,
         success_msg = "No columns are empty in the assay metadata",
         fail_msg = "Some columns are empty in the assay metadata"
       )

--- a/R/check-cols-empty.R
+++ b/R/check-cols-empty.R
@@ -5,7 +5,7 @@
 #' not tested for emptiness. This is due to the existing function
 #' `check_cols_complete()`, which ensures that the required columns are
 #' complete. By ignoring the required columns in `check_cols_empty()`,
-#' there are no conflicting results for the same column in the event
+#' there are no duplicated results for the same column in the event
 #' that a required column was also empty.
 #'
 #' @param data Data to check

--- a/R/check-cols-empty.R
+++ b/R/check-cols-empty.R
@@ -8,20 +8,27 @@
 #' @param strict If `FALSE`, return a `"check_warn"` object; if `TRUE`, return a
 #'   `"check_fail"` object
 #' @inheritParams check_values
+#' @inheritParams check_cols_complete
 #' @return A condition object indicating whether the data contains columns that
 #'   are empty.
 #' @export
 #' @examples
 #' dat <- data.frame(specimenID = c("x", "y"), organ = c(NA, NA))
 #' check_cols_empty(dat)
-check_cols_empty <- function(data, empty_values = c(NA, ""), strict = FALSE,
+check_cols_empty <- function(data, empty_values = c(NA, ""),
+                             required_cols = NULL, strict = FALSE,
                              success_msg = "No columns are empty",
                              fail_msg = "Some columns are empty") {
   if (is.null(data)) {
     return(NULL)
   }
+  ## Only check columns that are not required to be complete
+  not_required_cols <- setdiff(names(data), required_cols)
   ## Check if all columns have data
-  results <- purrr::map_lgl(data, function(x) all(x %in% empty_values))
+  results <- purrr::map_lgl(
+    data[, not_required_cols, drop = FALSE],
+    function(x) all(x %in% empty_values)
+  )
   behavior <- "Completely empty columns might be an accidental omission. If the columns are empty because the data does not exist, then this check can be ignored." # nolint
 
 

--- a/R/check-cols-empty.R
+++ b/R/check-cols-empty.R
@@ -1,6 +1,12 @@
 #' Check for empty columns
 #'
 #' Check for empty columns in the data and warn (or fail) if present.
+#' The function takes in a list of required column names that are
+#' not tested for emptiness. This is due to the existing function
+#' `check_cols_complete()`, which ensures that the required columns are
+#' complete. By ignoring the required columns in `check_cols_empty()`,
+#' there are no conflicting results for the same column in the event
+#' that a required column was also empty.
 #'
 #' @param data Data to check
 #' @param empty_values Values that are considered empty. Defaults to `NA` and

--- a/man/check_cols_empty.Rd
+++ b/man/check_cols_empty.Rd
@@ -30,6 +30,12 @@ are empty.
 }
 \description{
 Check for empty columns in the data and warn (or fail) if present.
+The function takes in a list of required column names that are
+not tested for emptiness. This is due to the existing function
+\code{check_cols_complete()}, which ensures that the required columns are
+complete. By ignoring the required columns in \code{check_cols_empty()},
+there are no conflicting results for the same column in the event
+that a required column was also empty.
 }
 \examples{
 dat <- data.frame(specimenID = c("x", "y"), organ = c(NA, NA))

--- a/man/check_cols_empty.Rd
+++ b/man/check_cols_empty.Rd
@@ -34,7 +34,7 @@ The function takes in a list of required column names that are
 not tested for emptiness. This is due to the existing function
 \code{check_cols_complete()}, which ensures that the required columns are
 complete. By ignoring the required columns in \code{check_cols_empty()},
-there are no conflicting results for the same column in the event
+there are no duplicated results for the same column in the event
 that a required column was also empty.
 }
 \examples{

--- a/man/check_cols_empty.Rd
+++ b/man/check_cols_empty.Rd
@@ -4,8 +4,8 @@
 \alias{check_cols_empty}
 \title{Check for empty columns}
 \usage{
-check_cols_empty(data, empty_values = c(NA, ""), strict = FALSE,
-  success_msg = "No columns are empty",
+check_cols_empty(data, empty_values = c(NA, ""), required_cols = NULL,
+  strict = FALSE, success_msg = "No columns are empty",
   fail_msg = "Some columns are empty")
 }
 \arguments{
@@ -13,6 +13,9 @@ check_cols_empty(data, empty_values = c(NA, ""), strict = FALSE,
 
 \item{empty_values}{Values that are considered empty. Defaults to \code{NA} and
 \code{""}.}
+
+\item{required_cols}{A character vector of the required columns to check for
+completeness.}
 
 \item{strict}{If \code{FALSE}, return a \code{"check_warn"} object; if \code{TRUE}, return a
 \code{"check_fail"} object}

--- a/tests/testthat/test-check-cols-empty.R
+++ b/tests/testthat/test-check-cols-empty.R
@@ -36,3 +36,12 @@ test_that("can customize empty values", {
   res <- check_cols_empty(dat, empty_values = NA)
   expect_true(inherits(res, "check_pass"))
 })
+
+test_that("`required_cols` are not checked for emptiness", {
+  dat <- data.frame(x = 1, y = NA, z = "")
+  res1 <- check_cols_empty(dat, required_cols = c("y", "z"))
+  res2 <- check_cols_empty(dat, required_cols = "y")
+  expect_true(inherits(res1, "check_pass"))
+  expect_true(inherits(res2, "check_warn"))
+  expect_equal(res2$data, "z")
+})


### PR DESCRIPTION
Fixes #162.

Updates `check_empty_cols()` to take a parameter `required_cols` similar to `check_cols_complete()`. `check_empty_cols()` then ignores/doesn't check the columns in `required_cols` for emptiness.

Changes:
- Add optional `required_cols` parameter to `check_empty_cols()`, and have it ignore columns in this list.
- Update documentation.
- Update tests for `check_empty_cols()` to make sure it's removing `required_cols` from the check.
- Update the metadata checks to pass in `required_cols`.