### PR TITLE
Add note about expected files for documentation

### DIFF
--- a/R/mod-upload-documentation.R
+++ b/R/mod-upload-documentation.R
@@ -25,14 +25,16 @@ upload_documents_ui <- function(id, study_link_human, study_link_animal) {
         shinyjs::disabled(
           fileInput(
             ns("study_doc"),
-            "Upload the study description file"
+            "Upload study description file (.txt, .docx, .md, .pdf, .tex)",
+            accept = c(".txt", ".docx", ".md", ".pdf", ".tex")
           )
         ),
         shinyjs::disabled(
           fileInput(
             ns("assay_doc"),
-            "Upload the assay description files",
-            multiple = TRUE
+            "Upload assay description files (.txt, .docx, .md, .pdf, .tex)",
+            multiple = TRUE,
+            accept = c(".txt", ".docx", ".md", ".pdf", ".tex")
           )
         ),
 

--- a/R/mod-upload-documentation.R
+++ b/R/mod-upload-documentation.R
@@ -26,7 +26,14 @@ upload_documents_ui <- function(id, study_link_human, study_link_animal) {
           fileInput(
             ns("study_doc"),
             "Upload study description file (.txt, .docx, .md, .pdf, .tex)",
-            accept = c(".txt", ".docx", ".md", ".pdf", ".tex")
+            accept = c(
+              "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # nolint
+              "application/msword",
+              "application/pdf",
+              "text/plain",
+              "application/x-tex",
+              "text/markdown"
+            )
           )
         ),
         shinyjs::disabled(
@@ -34,7 +41,14 @@ upload_documents_ui <- function(id, study_link_human, study_link_animal) {
             ns("assay_doc"),
             "Upload assay description files (.txt, .docx, .md, .pdf, .tex)",
             multiple = TRUE,
-            accept = c(".txt", ".docx", ".md", ".pdf", ".tex")
+            accept = c(
+              "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # nolint
+              "application/msword",
+              "application/pdf",
+              "text/plain",
+              "application/x-tex",
+              "text/markdown"
+            )
           )
         ),
 


### PR DESCRIPTION
Fixes #159. 

Updated:
- The documetation `fileInput`s expect .txt, .docx, .md, .pdf, and .tex. Note that this doesn't force the document upload to be one of these types; it simply makes the file explorer show these file types versus all file types.
- Added a note in the label for each documentation `fileInput` that gives the expected file types.