### PR TITLE
Remove name parameter from `save_to_synapse()` & update calls

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -400,7 +400,6 @@ app_server <- function(input, output, session) {
           save_to_synapse(
             files$indiv,
             parent = created_folder,
-            name = files$indiv$name,
             annotations = list(
               study = study_name(),
               metadataType = "individual",
@@ -412,7 +411,6 @@ app_server <- function(input, output, session) {
           save_to_synapse(
             files$biosp,
             parent = created_folder,
-            name = files$biosp$name,
             annotations = list(
               study = study_name(),
               metadataType = "biospecimen",
@@ -424,7 +422,6 @@ app_server <- function(input, output, session) {
           save_to_synapse(
             files$assay,
             parent = created_folder,
-            name = files$assay$name,
             annotations = list(
               study = study_name(),
               metadataType = "assay",
@@ -437,7 +434,6 @@ app_server <- function(input, output, session) {
           save_to_synapse(
             files$manifest,
             parent = created_folder,
-            name = files$manifest$name,
             annotations = list(study = study_name())
           )
         }

--- a/R/mod-upload-documentation.R
+++ b/R/mod-upload-documentation.R
@@ -192,7 +192,6 @@ upload_documents_server <- function(input, output, session,
           save_to_synapse(
             list(datapath = x, name = y),
             parent = created_docs_folder,
-            name = y,
             annotations = doc_annots()
           )
         })

--- a/R/utils.R
+++ b/R/utils.R
@@ -50,12 +50,11 @@ get_annotation <- function(ids, key) {
 ## Save uploaded files to Synapse
 save_to_synapse <- function(input_file,
                             parent,
-                            name = NULL,
                             annotations = NULL) {
   file_to_upload <- synapser::File(
     input_file$datapath,
     parent = parent,
-    name = name,
+    name = input_file$name,
     annotations = annotations
   )
   synapser::synStore(file_to_upload)


### PR DESCRIPTION
Fixes #199.

The `input_file` parameter includes the file name already. This update:
- removes the redundant `name` parameter from `save_to_synapse()`,
- updates the synapse file entity call to use `input_file$name`,
- updates all calls to `save_to_synapse()` to remove the name parameter.