### PR TITLE
Update check_ids_match reporting based on bidirectional flag

### DIFF
--- a/R/check-ids-match.R
+++ b/R/check-ids-match.R
@@ -64,15 +64,24 @@ check_ids_match <- function(x, y, idcol = c("individualID", "specimenID"),
       behavior = behavior
     )
   } else {
+    if (bidirectional == FALSE) {
+      data <- stats::setNames(
+        list(missing_from_x),
+        glue::glue("Missing from {xname}")
+      )
+    }
+    else {
+      data <- stats::setNames(
+        list(missing_from_x, missing_from_y),
+        glue::glue("Missing from {c(xname, yname)}")
+      )
+    }
     check_fail(
       msg = glue::glue(
         "{idcol} values are mismatched between {xname} and {yname}"
       ),
       behavior = behavior,
-      data = stats::setNames(
-        list(missing_from_x, missing_from_y),
-        glue::glue("Missing from {c(xname, yname)}")
-      )
+      data = data
     )
   }
 }

--- a/tests/testthat/test-check-ids-match.R
+++ b/tests/testthat/test-check-ids-match.R
@@ -185,7 +185,8 @@ test_that("check_ids_match bidirectional arg returns relevant data", {
   )
 expect_equal(res1$data, list(`Missing from x` = 5, `Missing from y` = 3:4))
 expect_equal(length(res1$data), 2)
-  expect_equal(res2$data[[1]], 5)
+  expect_equal(res2$data, list(`Missing from x` = 5))
+  expect_equal(length(res2$data), 1)
 })
 
 test_that("check_ids_match data gets default names if not provided", {

--- a/tests/testthat/test-check-ids-match.R
+++ b/tests/testthat/test-check-ids-match.R
@@ -183,7 +183,8 @@ test_that("check_ids_match bidirectional arg returns relevant data", {
     idcol = "individualID",
     bidirectional = FALSE
   )
-  expect_equal(c(res1$data[[1]], res1$data[[2]]), c(5, 3, 4))
+expect_equal(res1$data, list(`Missing from x` = 5, `Missing from y` = 3:4))
+expect_equal(length(res1$data), 2)
   expect_equal(res2$data[[1]], 5)
 })
 

--- a/tests/testthat/test-check-ids-match.R
+++ b/tests/testthat/test-check-ids-match.R
@@ -183,8 +183,11 @@ test_that("check_ids_match bidirectional arg returns relevant data", {
     idcol = "individualID",
     bidirectional = FALSE
   )
-expect_equal(res1$data, list(`Missing from x` = 5, `Missing from y` = 3:4))
-expect_equal(length(res1$data), 2)
+  expect_equal(
+    res1$data,
+    list(`Missing from x` = 5, `Missing from y` = 3:4)
+  )
+  expect_equal(length(res1$data), 2)
   expect_equal(res2$data, list(`Missing from x` = 5))
   expect_equal(length(res2$data), 1)
 })

--- a/tests/testthat/test-check-ids-match.R
+++ b/tests/testthat/test-check-ids-match.R
@@ -168,6 +168,25 @@ test_that("check_ids_match bidirectional arg looks only in one direction", {
   expect_equal(res2$data[[1]], c(3, 4))
 })
 
+test_that("check_ids_match bidirectional arg returns relevant data", {
+  meta <- data.frame(individualID = 1:4)
+  manifest <- data.frame(individualID = c(1:2, 5))
+  res1 <- check_ids_match(
+    x = meta,
+    y = manifest,
+    idcol = "individualID",
+    bidirectional = TRUE
+  )
+  res2 <- check_ids_match(
+    x = meta,
+    y = manifest,
+    idcol = "individualID",
+    bidirectional = FALSE
+  )
+  expect_equal(c(res1$data[[1]], res1$data[[2]]), c(5, 3, 4))
+  expect_equal(res2$data[[1]], 5)
+})
+
 test_that("check_ids_match data gets default names if not provided", {
   x <- data.frame(individualID = 1:3)
   y <- data.frame(individualID = 4:6)


### PR DESCRIPTION
Fixes #196.

Updates the `check_ids_match()` to only return relevant missing values based on the bidirectional flag. Added test to check that the reporting is correct based on the flag.