### PR TITLE
Add individualIDs from manifest to valueBox count

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -546,7 +546,11 @@ app_server <- function(input, output, session) {
       valueBox(
         length(
           unique(
-            c(indiv()$individualID, biosp()$individualID)
+            c(
+              indiv()$individualID,
+              biosp()$individualID,
+              manifest()$individualID
+            )
           )
         ),
         "Individuals",


### PR DESCRIPTION
Changes proposed in this pull request:

- Add individualID's from manifest to the valueBox count in Data Summary.

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: Nope. There are none for that section of the app, yet.
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: N/A
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: N/A
