### PR TITLE
Open protocol example links in new tab

### DIFF
--- a/R/mod-upload-documentation.R
+++ b/R/mod-upload-documentation.R
@@ -235,9 +235,9 @@ upload_docs_instruct_text <- function(study_link_human, study_link_animal,
     ),
     p(
       "Detailed protocols are highly recommended. These can be uploaded as pdf together with the data-files, or as links to protocol repositories such as ",
-      tags$a(href = "https://www.protocols.io", "protocols.io"),
+      tags$a(href = "https://www.protocols.io", "protocols.io", target = "_blank"),
       (" or "),
-      tags$a(href = "https://theolb.readthedocs.io/en/latest/index.html#", "Open Lab Book.")
+      tags$a(href = "https://theolb.readthedocs.io/en/latest/index.html#", "Open Lab Book.", target = "_blank")
     )
     # nolint end
   )


### PR DESCRIPTION
Fixes #229.

Changes proposed in this pull request:

- Make the protocol examples in study documentation open in a new tab when clicked.

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: N/A
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: N/A
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: N/A
