### PR TITLE
Fix pkgdown deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ jobs:
         provider: script
         script: Rscript -e 'pkgdown::deploy_site_github(verbose = TRUE)'
         skip_cleanup: true
+        on:
+          branch: pkgdown-test
 
 r_github_packages:
   - jimhester/lintr

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ matrix:
       provider: script
       script: Rscript -e 'pkgdown::deploy_site_github(verbose = TRUE)'
       skip_cleanup: true
-      on:
-        branch: pkgdown-test
   - if: type = pull_request
     stage: lint
     r: release

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,28 +4,27 @@ language: R
 sudo: false
 cache: packages
 
-r:
-- 3.4
-- oldrel
-- release
-- devel
-jobs:
+matrix:
   include:
-    - if: type = pull_request
-      stage: lint
-      r: release
-      script:
-        - |
-          R CMD INSTALL $PKG_TARBALL
-          Rscript -e 'lintr::lint_package()'
-    - stage: deploy
-      before_cache: Rscript -e 'remotes::install_cran("pkgdown")'
-      deploy:
-        provider: script
-        script: Rscript -e 'pkgdown::deploy_site_github(verbose = TRUE)'
-        skip_cleanup: true
-        on:
-          branch: pkgdown-test
+  - r: devel
+  - if: type = pull_request
+    stage: lint
+    r: release
+    script:
+      - |
+        R CMD INSTALL $PKG_TARBALL
+        Rscript -e 'lintr::lint_package()'
+  - r: release
+    before_cache:
+    - Rscript -e 'remotes::install_cran("pkgdown")'
+    deploy:
+      provider: script
+      script: Rscript -e 'pkgdown::deploy_site_github(verbose = TRUE)'
+      skip_cleanup: true
+      on:
+        branch: pkgdown-test
+  - r: 3.5
+  - r: 3.4
 
 r_github_packages:
   - jimhester/lintr

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache: packages
 matrix:
   include:
   - r: devel
+  - r: release
   - if: type = pull_request
     stage: lint
     r: release
@@ -14,7 +15,8 @@ matrix:
       - |
         R CMD INSTALL $PKG_TARBALL
         Rscript -e 'lintr::lint_package()'
-  - r: release
+  - stage: deploy
+    r: release
     before_cache:
     - Rscript -e 'remotes::install_cran("pkgdown")'
     deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,8 @@ matrix:
   include:
   - r: devel
   - r: release
-  - if: type = pull_request
-    stage: lint
-    r: release
-    script:
-      - |
-        R CMD INSTALL $PKG_TARBALL
-        Rscript -e 'lintr::lint_package()'
+  - r: 3.5
+  - r: 3.4
   - stage: deploy
     r: release
     before_cache:
@@ -25,8 +20,13 @@ matrix:
       skip_cleanup: true
       on:
         branch: pkgdown-test
-  - r: 3.5
-  - r: 3.4
+  - if: type = pull_request
+    stage: lint
+    r: release
+    script:
+      - |
+        R CMD INSTALL $PKG_TARBALL
+        Rscript -e 'lintr::lint_package()'
 
 r_github_packages:
   - jimhester/lintr

--- a/R/app-reporting.R
+++ b/R/app-reporting.R
@@ -110,7 +110,7 @@ report_unsatisfied_requirements <- function(membership, certified) {
       purrr::map_chr(
         membership$data,
         function(x) {
-          glue::glue("<a href=\"https://www.synapse.org/#!Team:{x}\">https://www.synapse.org/#!Team:{x}</a>") # nolint
+          glue::glue("<a href=\"https://www.synapse.org/#!Team:{x}\">https://www.synapse.org/#!Team:{x}</a>")
         }
       ),
       sep = "<br>"

--- a/R/app-reporting.R
+++ b/R/app-reporting.R
@@ -110,7 +110,7 @@ report_unsatisfied_requirements <- function(membership, certified) {
       purrr::map_chr(
         membership$data,
         function(x) {
-          glue::glue("<a href=\"https://www.synapse.org/#!Team:{x}\">https://www.synapse.org/#!Team:{x}</a>")
+          glue::glue("<a href=\"https://www.synapse.org/#!Team:{x}\">https://www.synapse.org/#!Team:{x}</a>") # nolint
         }
       ),
       sep = "<br>"


### PR DESCRIPTION
Fixes #233. I have rearranged the build matrix and ensured that pkgdown deployment happens on `r: release`. Previously it was running on R 3.4.4 and failing due to this rmarkdown issue https://github.com/rstudio/rmarkdown/issues/1743. Opening this as a draft first to test that I haven't broken the linting stage.