### PR TITLE
Remove observeEvent assignment

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -26,7 +26,7 @@ app_server <- function(input, output, session) {
     )
   })
 
-  foo <- observeEvent(input$cookie, {
+  observeEvent(input$cookie, {
     syn$login(sessionToken = input$cookie)
 
     ## Check if user is in AMP-AD Consortium team (needed in order to create


### PR DESCRIPTION
This was copied from the [SynapseShinyApp template](https://github.com/Sage-Bionetworks/synapseshinyapp) and isn't necessary as far as I can tell.