### PR TITLE
Add AMP-AD specific metadata to validation

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -91,9 +91,10 @@ app_server <- function(input, output, session) {
     })
 
     ## Download annotation definitions
-    annots <- get_synapse_annotations(
-      synID = config::get("annotations_table"),
-      syn
+    annots <- purrr::map_dfr(
+      config::get("annotations_table"),
+      get_synapse_annotations,
+      syn = syn
     )
 
     ## Store files in separate variable to be able to reset inputs to NULL

--- a/config.yml
+++ b/config.yml
@@ -38,6 +38,9 @@ default:
 
 amp-ad:
   parent: "syn20506363"
+  annotations_table:
+    - "syn10242922"
+    - "syn21459391"
   teams:
     - "3320424"
   study_link_ref: "https://adknowledgeportal.synapse.org/#/DataAccess/AcknowledgementStatements"

--- a/config.yml
+++ b/config.yml
@@ -41,6 +41,7 @@ amp-ad:
   annotations_table:
     - "syn10242922"
     - "syn21459391"
+  annotations_link: "https://shinypro.synapse.org/users/kwoo/amp-ad-metadata-dictionary/"
   teams:
     - "3320424"
   study_link_ref: "https://adknowledgeportal.synapse.org/#/DataAccess/AcknowledgementStatements"


### PR DESCRIPTION
Fixes #228 

- Adds the non-annotation metadata values to the validation
- Replaces the annotations link for AMP-AD with a link to a different shiny app describing all keys/values (our regular synapse annotations + the AMP-AD specific metadata values)
