### PR TITLE
Informative error if there are multiple column types in annotations

### DIFF
--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -203,8 +203,18 @@ check_type <- function(values, key, annotations, whitelist_values = NULL,
     ## need to be sure to get a vector if annotations is a tibble
     coltype <- unlist(coltype)
   }
+  coltype <- unique(as.character(coltype))
+  # coltype should be unique, if not then switch() will fail, so let's stop with
+  # an informative error
+  if (length(coltype) != 1) {
+    stop(
+      glue::glue("Cannot validate values for key '{key}' because multiple valid types were found. Please contact an administrator to fix the data dictionary."), # nolint
+      call. = FALSE
+    )
+  }
+
   correct_class <- switch(
-    unique(as.character(coltype)),
+    coltype,
     "STRING" = "character",
     "BOOLEAN" = "logical",
     "INTEGER" = "integer",

--- a/tests/testthat/test-check-annotation-values.R
+++ b/tests/testthat/test-check-annotation-values.R
@@ -401,6 +401,12 @@ test_that("whitelist_values works in check_type", {
   )
 })
 
+test_that("Multiple column types produces an error", {
+  annotations <- tibble(key = c("x", "x"), columnType = c("STRING", "DOUBLE"))
+  a <- c("a")
+  expect_error(check_type(a, "x", annotations, return_valid = FALSE))
+})
+
 ## can_coerce() ----------------------------------------------------------------
 
 test_that("can_coerce() returns TRUE for numeric/integer/boolean->character", {


### PR DESCRIPTION
Fixes #249 

Changes proposed in this pull request:

- Gives an informative error if checking annotation types fails due to there being multiple annotation types defined.

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: yes
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: NA
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: NA
