### PR TITLE
Only deploy pkgdown site when running travis in Sage-Bionetworks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ matrix:
   - r: release
   - r: 3.5
   - r: 3.4
-  - stage: deploy
+  - if: branch = master
+    stage: deploy
     r: release
     before_cache:
     - Rscript -e 'remotes::install_cran("pkgdown")'
@@ -21,6 +22,9 @@ matrix:
       provider: script
       script: Rscript -e 'pkgdown::deploy_site_github(verbose = TRUE)'
       skip_cleanup: true
+      on:
+        repo: Sage-Bionetworks/dccvalidator
+        branch: master
   - if: type = pull_request
     stage: lint
     r: release


### PR DESCRIPTION
Inspired by something @kdaily showed, this ensures that the deploy stage only runs for builds within Sage-Bionetworks (so if someone set up travis on their fork of the repo, it would not try to deploy)