### PR TITLE
Ensure methods have all arguments of the generics

### DIFF
--- a/R/check-annotation-keys.R
+++ b/R/check-annotation-keys.R
@@ -39,11 +39,13 @@ check_annotation_keys <- function(x, annotations, ...) {
 }
 
 #' @export
+#' @rdname check_annotation_keys
 check_annotation_keys.NULL <- function(x, annotations, ...) {
   return(NULL)
 }
 
 #' @export
+#' @rdname check_annotation_keys
 check_annotation_keys.synapseclient.entity.File <- function(x, annotations, syn, ...) { # nolint
   file_annots <- dict_to_list(syn$getAnnotations(x))
   check_keys(
@@ -55,11 +57,13 @@ check_annotation_keys.synapseclient.entity.File <- function(x, annotations, syn,
 }
 
 #' @export
+#' @rdname check_annotation_keys
 check_annotation_keys.data.frame <- function(x, annotations, ...) {
   check_keys(names(x), annotations, ..., return_valid = FALSE)
 }
 
 #' @export
+#' @rdname check_annotation_keys
 check_annotation_keys.synapseclient.table.CsvFileTable <- function(x, annotations, ...) { # nolint
   dat <- utils::read.csv(x$filepath, stringsAsFactors = FALSE)
   fv_synapse_cols <- c(
@@ -98,11 +102,13 @@ valid_annotation_keys <- function(x, annotations, ...) {
 }
 
 #' @export
+#' @rdname valid_annotation_keys
 valid_annotation_keys.NULL <- function(x, annotations, ...) {
   return(NULL)
 }
 
 #' @export
+#' @rdname valid_annotation_keys
 valid_annotation_keys.synapseclient.entity.File <- function(x, annotations, syn, ...) { # nolint
   file_annots <- dict_to_list(syn$getAnnotations(x))
   check_keys(
@@ -114,11 +120,13 @@ valid_annotation_keys.synapseclient.entity.File <- function(x, annotations, syn,
 }
 
 #' @export
+#' @rdname valid_annotation_keys
 valid_annotation_keys.data.frame <- function(x, annotations, ...) {
   check_keys(names(x), annotations, ..., return_valid = TRUE)
 }
 
 #' @export
+#' @rdname valid_annotation_keys
 valid_annotation_keys.synapseclient.table.CsvFileTable <- function(x, annotations, ...) { # nolint
   dat <- utils::read.csv(x$filepath, stringsAsFactors = FALSE)
   fv_synapse_cols <- c(

--- a/R/check-annotation-keys.R
+++ b/R/check-annotation-keys.R
@@ -8,7 +8,7 @@
 #' @param annotations A data frame of annotation definitions. Must contain at
 #'   least three columns: `key`, `value`, and `columnType`.
 #' @param ... Additional parameters passed to [`check_keys()`]
-#' @inheritParams get_synapse_annotations
+#' @param syn Synapse client object
 #' @return A condition object indicating whether keys match the given annotation
 #'   dictionary. Erroneous keys are included as data within the object.
 #' @export
@@ -34,7 +34,7 @@
 #' my_file <- syn$get("syn11931757", downloadFile = FALSE)
 #' check_annotation_keys(my_file, syn = syn)
 #' }
-check_annotation_keys <- function(x, annotations, syn, ...) {
+check_annotation_keys <- function(x, annotations, ...) {
   UseMethod("check_annotation_keys", x)
 }
 
@@ -90,10 +90,10 @@ check_annotation_keys.synapseclient.table.CsvFileTable <- function(x, annotation
 #' file, or Synapse file view.
 #'
 #' @inheritParams check_annotation_keys
-#' @inheritParams get_synapse_annotations
+#' @param syn Synapse client object
 #' @return A vector of valid annotation keys present in `x`.
 #' @export
-valid_annotation_keys <- function(x, annotations, syn, ...) {
+valid_annotation_keys <- function(x, annotations, ...) {
   UseMethod("valid_annotation_keys", x)
 }
 

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -58,11 +58,13 @@ check_annotation_values <- function(x, annotations, ...) {
 }
 
 #' @export
+#' @rdname check_annotation_values
 check_annotation_values.NULL <- function(x, annotations, ...) {
   return(NULL)
 }
 
 #' @export
+#' @rdname check_annotation_values
 check_annotation_values.synapseclient.entity.File <- function(x, annotations, syn, ...) { # nolint
   annots <- dict_to_list(syn$getAnnotations(x))
   check_values(
@@ -75,6 +77,7 @@ check_annotation_values.synapseclient.entity.File <- function(x, annotations, sy
 }
 
 #' @export
+#' @rdname check_annotation_values
 check_annotation_values.data.frame <- function(x, annotations, ...) {
   check_values(
     x,
@@ -85,6 +88,7 @@ check_annotation_values.data.frame <- function(x, annotations, ...) {
 }
 
 #' @export
+#' @rdname check_annotation_values
 check_annotation_values.synapseclient.table.CsvFileTable <- function(x, annotations, ...) { # nolint
   dat <- utils::read.csv(x$filepath, stringsAsFactors = FALSE, na.strings = "")
   fv_synapse_cols <- c(
@@ -128,11 +132,13 @@ valid_annotation_values <- function(x, annotations, ...) {
 }
 
 #' @export
+#' @rdname valid_annotation_values
 valid_annotation_values.NULL <- function(x, annotations, ...) {
   return(NULL)
 }
 
 #' @export
+#' @rdname valid_annotation_values
 valid_annotation_values.synapseclient.entity.File <- function(x, annotations, syn, ...) { # nolint
   annots <- dict_to_list(syn$getAnnotations(x))
   check_values(
@@ -144,6 +150,7 @@ valid_annotation_values.synapseclient.entity.File <- function(x, annotations, sy
 }
 
 #' @export
+#' @rdname valid_annotation_values
 valid_annotation_values.data.frame <- function(x, annotations, ...) {
   check_values(
     x,
@@ -154,6 +161,7 @@ valid_annotation_values.data.frame <- function(x, annotations, ...) {
 }
 
 #' @export
+#' @rdname valid_annotation_values
 valid_annotation_values.synapseclient.table.CsvFileTable <- function(x, annotations, ...) { # nolint
   dat <- utils::read.csv(x$filepath, stringsAsFactors = FALSE)
   fv_synapse_cols <- c(

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -11,8 +11,8 @@
 #' as valid (see [can_coerce()]).
 #'
 #' @inheritParams check_annotation_keys
-#' @inheritParams get_synapse_annotations
 #' @param ... Additional options to [`check_values()`]
+#' @param syn Synapse client object
 #' @return A condition object indicating whether all annotation values are
 #'   valid. Invalid annotation values are included as data within the object.
 #' @export
@@ -53,7 +53,7 @@
 #'   syn = syn
 #' )
 #' }
-check_annotation_values <- function(x, annotations, syn, ...) {
+check_annotation_values <- function(x, annotations, ...) {
   UseMethod("check_annotation_values", x)
 }
 
@@ -120,10 +120,10 @@ check_annotation_values.synapseclient.table.CsvFileTable <- function(x, annotati
 #' file, or Synapse file view.
 #'
 #' @inheritParams check_annotation_values
-#' @inheritParams get_synapse_annotations
+#' @param syn Synapse client object
 #' @return A named list of valid annotation values.
 #' @export
-valid_annotation_values <- function(x, annotations, syn, ...) {
+valid_annotation_values <- function(x, annotations, ...) {
   UseMethod("valid_annotation_values", x)
 }
 

--- a/man/check_annotation_keys.Rd
+++ b/man/check_annotation_keys.Rd
@@ -2,9 +2,23 @@
 % Please edit documentation in R/check-annotation-keys.R
 \name{check_annotation_keys}
 \alias{check_annotation_keys}
+\alias{check_annotation_keys.NULL}
+\alias{check_annotation_keys.synapseclient.entity.File}
+\alias{check_annotation_keys.data.frame}
+\alias{check_annotation_keys.synapseclient.table.CsvFileTable}
 \title{Check annotation keys}
 \usage{
 check_annotation_keys(x, annotations, ...)
+
+\method{check_annotation_keys}{NULL}(x, annotations, ...)
+
+\method{check_annotation_keys}{synapseclient.entity.File}(x, annotations,
+  syn, ...)
+
+\method{check_annotation_keys}{data.frame}(x, annotations, ...)
+
+\method{check_annotation_keys}{synapseclient.table.CsvFileTable}(x,
+  annotations, ...)
 }
 \arguments{
 \item{x}{An object to check.}

--- a/man/check_annotation_keys.Rd
+++ b/man/check_annotation_keys.Rd
@@ -4,7 +4,7 @@
 \alias{check_annotation_keys}
 \title{Check annotation keys}
 \usage{
-check_annotation_keys(x, annotations, syn, ...)
+check_annotation_keys(x, annotations, ...)
 }
 \arguments{
 \item{x}{An object to check.}
@@ -12,9 +12,9 @@ check_annotation_keys(x, annotations, syn, ...)
 \item{annotations}{A data frame of annotation definitions. Must contain at
 least three columns: \code{key}, \code{value}, and \code{columnType}.}
 
-\item{syn}{Synapse client object}
-
 \item{...}{Additional parameters passed to \code{\link[=check_keys]{check_keys()}}}
+
+\item{syn}{Synapse client object}
 }
 \value{
 A condition object indicating whether keys match the given annotation

--- a/man/check_annotation_values.Rd
+++ b/man/check_annotation_values.Rd
@@ -4,7 +4,7 @@
 \alias{check_annotation_values}
 \title{Check annotation values}
 \usage{
-check_annotation_values(x, annotations, syn, ...)
+check_annotation_values(x, annotations, ...)
 }
 \arguments{
 \item{x}{An object to check.}
@@ -12,9 +12,9 @@ check_annotation_values(x, annotations, syn, ...)
 \item{annotations}{A data frame of annotation definitions. Must contain at
 least three columns: \code{key}, \code{value}, and \code{columnType}.}
 
-\item{syn}{Synapse client object}
-
 \item{...}{Additional options to \code{\link[=check_values]{check_values()}}}
+
+\item{syn}{Synapse client object}
 }
 \value{
 A condition object indicating whether all annotation values are

--- a/man/check_annotation_values.Rd
+++ b/man/check_annotation_values.Rd
@@ -2,9 +2,23 @@
 % Please edit documentation in R/check-annotation-values.R
 \name{check_annotation_values}
 \alias{check_annotation_values}
+\alias{check_annotation_values.NULL}
+\alias{check_annotation_values.synapseclient.entity.File}
+\alias{check_annotation_values.data.frame}
+\alias{check_annotation_values.synapseclient.table.CsvFileTable}
 \title{Check annotation values}
 \usage{
 check_annotation_values(x, annotations, ...)
+
+\method{check_annotation_values}{NULL}(x, annotations, ...)
+
+\method{check_annotation_values}{synapseclient.entity.File}(x, annotations,
+  syn, ...)
+
+\method{check_annotation_values}{data.frame}(x, annotations, ...)
+
+\method{check_annotation_values}{synapseclient.table.CsvFileTable}(x,
+  annotations, ...)
 }
 \arguments{
 \item{x}{An object to check.}

--- a/man/valid_annotation_keys.Rd
+++ b/man/valid_annotation_keys.Rd
@@ -4,7 +4,7 @@
 \alias{valid_annotation_keys}
 \title{Valid annotation keys}
 \usage{
-valid_annotation_keys(x, annotations, syn, ...)
+valid_annotation_keys(x, annotations, ...)
 }
 \arguments{
 \item{x}{An object to check.}
@@ -12,9 +12,9 @@ valid_annotation_keys(x, annotations, syn, ...)
 \item{annotations}{A data frame of annotation definitions. Must contain at
 least three columns: \code{key}, \code{value}, and \code{columnType}.}
 
-\item{syn}{Synapse client object}
-
 \item{...}{Additional parameters passed to \code{\link[=check_keys]{check_keys()}}}
+
+\item{syn}{Synapse client object}
 }
 \value{
 A vector of valid annotation keys present in \code{x}.

--- a/man/valid_annotation_keys.Rd
+++ b/man/valid_annotation_keys.Rd
@@ -2,9 +2,23 @@
 % Please edit documentation in R/check-annotation-keys.R
 \name{valid_annotation_keys}
 \alias{valid_annotation_keys}
+\alias{valid_annotation_keys.NULL}
+\alias{valid_annotation_keys.synapseclient.entity.File}
+\alias{valid_annotation_keys.data.frame}
+\alias{valid_annotation_keys.synapseclient.table.CsvFileTable}
 \title{Valid annotation keys}
 \usage{
 valid_annotation_keys(x, annotations, ...)
+
+\method{valid_annotation_keys}{NULL}(x, annotations, ...)
+
+\method{valid_annotation_keys}{synapseclient.entity.File}(x, annotations,
+  syn, ...)
+
+\method{valid_annotation_keys}{data.frame}(x, annotations, ...)
+
+\method{valid_annotation_keys}{synapseclient.table.CsvFileTable}(x,
+  annotations, ...)
 }
 \arguments{
 \item{x}{An object to check.}

--- a/man/valid_annotation_values.Rd
+++ b/man/valid_annotation_values.Rd
@@ -4,7 +4,7 @@
 \alias{valid_annotation_values}
 \title{Valid annotation values}
 \usage{
-valid_annotation_values(x, annotations, syn, ...)
+valid_annotation_values(x, annotations, ...)
 }
 \arguments{
 \item{x}{An object to check.}
@@ -12,9 +12,9 @@ valid_annotation_values(x, annotations, syn, ...)
 \item{annotations}{A data frame of annotation definitions. Must contain at
 least three columns: \code{key}, \code{value}, and \code{columnType}.}
 
-\item{syn}{Synapse client object}
-
 \item{...}{Additional options to \code{\link[=check_values]{check_values()}}}
+
+\item{syn}{Synapse client object}
 }
 \value{
 A named list of valid annotation values.

--- a/man/valid_annotation_values.Rd
+++ b/man/valid_annotation_values.Rd
@@ -2,9 +2,23 @@
 % Please edit documentation in R/check-annotation-values.R
 \name{valid_annotation_values}
 \alias{valid_annotation_values}
+\alias{valid_annotation_values.NULL}
+\alias{valid_annotation_values.synapseclient.entity.File}
+\alias{valid_annotation_values.data.frame}
+\alias{valid_annotation_values.synapseclient.table.CsvFileTable}
 \title{Valid annotation values}
 \usage{
 valid_annotation_values(x, annotations, ...)
+
+\method{valid_annotation_values}{NULL}(x, annotations, ...)
+
+\method{valid_annotation_values}{synapseclient.entity.File}(x, annotations,
+  syn, ...)
+
+\method{valid_annotation_values}{data.frame}(x, annotations, ...)
+
+\method{valid_annotation_values}{synapseclient.table.CsvFileTable}(x,
+  annotations, ...)
 }
 \arguments{
 \item{x}{An object to check.}


### PR DESCRIPTION
Part of #217; removes `syn` as an argument from the generics for `check_annotation_keys()`/`check_annotation_values()` (and the `valid_*()` counterparts) because it is only needed for some methods.