### PR TITLE
Skip test if syn is NULL

### DIFF
--- a/tests/testthat/test-check-col-names.R
+++ b/tests/testthat/test-check-col-names.R
@@ -24,6 +24,8 @@ test_that("check_col_names returns missing columns in the data", {
 })
 
 test_that("get_template fails when not logged in to Synapse", {
+  skip_if(is.null(syn))
+
   syn$logout()
   expect_error(get_template("syn12973252", syn))
 })


### PR DESCRIPTION
This was flagged by `rhub::check_for_cran()`; if the synapse client can't be instantiated, then this test will error. This PR avoids the error by skipping the test if the synapse client isn't available (`syn` is `NULL`).