### PR TITLE
Read in files with readr for more stable col names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,7 @@ Imports:
     markdown,
     pkgload,
     purrr,
+    readr,
     readxl,
     reticulate,
     rlang,

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -127,43 +127,25 @@ app_server <- function(input, output, session) {
       if (is.null(files$manifest)) {
         return(NULL)
       }
-      utils::read.table(
-        files$manifest$datapath,
-        sep = "\t",
-        header = TRUE,
-        na.strings = "",
-        stringsAsFactors = FALSE
-      )
+      readr::read_tsv(files$manifest$datapath)
     })
     indiv <- reactive({
       if (is.null(files$indiv)) {
         return(NULL)
       }
-      utils::read.csv(
-        files$indiv$datapath,
-        na.strings = "",
-        stringsAsFactors = FALSE
-      )
+      readr::read_csv(files$indiv$datapath)
     })
     biosp <- reactive({
       if (is.null(files$biosp)) {
         return(NULL)
       }
-      utils::read.csv(
-        files$biosp$datapath,
-        na.strings = "",
-        stringsAsFactors = FALSE
-      )
+      readr::read_csv(files$biosp$datapath)
     })
     assay <- reactive({
       if (is.null(files$assay)) {
         return(NULL)
       }
-      utils::read.csv(
-        files$assay$datapath,
-        na.strings = "",
-        stringsAsFactors = FALSE
-      )
+      readr::read_csv(files$assay$datapath)
     })
 
     # Location of templates


### PR DESCRIPTION
Fixes #261 

Changes proposed in this pull request:

- Reads all user-supplied files with readr instead of base `read.csv()`/`read.table()`.
