### PR TITLE
Use describeIn to document methods

### DIFF
--- a/R/check-annotation-keys.R
+++ b/R/check-annotation-keys.R
@@ -49,13 +49,13 @@ check_annotation_keys <- function(x, annotations, ...) {
 }
 
 #' @export
-#' @rdname check_annotation_keys
+#' @describeIn check_annotation_keys Return NULL
 check_annotation_keys.NULL <- function(x, annotations, ...) {
   return(NULL)
 }
 
 #' @export
-#' @rdname check_annotation_keys
+#' @describeIn check_annotation_keys Check annotation keys in a Synapse file
 check_annotation_keys.synapseclient.entity.File <- function(x, annotations, syn, ...) { # nolint
   file_annots <- dict_to_list(syn$getAnnotations(x))
   check_keys(
@@ -67,13 +67,13 @@ check_annotation_keys.synapseclient.entity.File <- function(x, annotations, syn,
 }
 
 #' @export
-#' @rdname check_annotation_keys
+#' @describeIn check_annotation_keys Check annotation keys in a data frame
 check_annotation_keys.data.frame <- function(x, annotations, ...) {
   check_keys(names(x), annotations, ..., return_valid = FALSE)
 }
 
 #' @export
-#' @rdname check_annotation_keys
+#' @describeIn check_annotation_keys Check annotation keys for a Synapse table
 check_annotation_keys.synapseclient.table.CsvFileTable <- function(x, annotations, ...) { # nolint
   dat <- utils::read.csv(x$filepath, stringsAsFactors = FALSE)
   fv_synapse_cols <- c(
@@ -122,13 +122,13 @@ valid_annotation_keys <- function(x, annotations, ...) {
 }
 
 #' @export
-#' @rdname valid_annotation_keys
+#' @describeIn valid_annotation_keys Return NULL
 valid_annotation_keys.NULL <- function(x, annotations, ...) {
   return(NULL)
 }
 
 #' @export
-#' @rdname valid_annotation_keys
+#' @describeIn valid_annotation_keys Valid annotation keys on a Synapse file
 valid_annotation_keys.synapseclient.entity.File <- function(x, annotations, syn, ...) { # nolint
   file_annots <- dict_to_list(syn$getAnnotations(x))
   check_keys(
@@ -140,13 +140,13 @@ valid_annotation_keys.synapseclient.entity.File <- function(x, annotations, syn,
 }
 
 #' @export
-#' @rdname valid_annotation_keys
+#' @describeIn valid_annotation_keys Valid annotation keys in a data frame
 valid_annotation_keys.data.frame <- function(x, annotations, ...) {
   check_keys(names(x), annotations, ..., return_valid = TRUE)
 }
 
 #' @export
-#' @rdname valid_annotation_keys
+#' @describeIn valid_annotation_keys Valid annotation keys in a Synapse table
 valid_annotation_keys.synapseclient.table.CsvFileTable <- function(x, annotations, ...) { # nolint
   dat <- utils::read.csv(x$filepath, stringsAsFactors = FALSE)
   fv_synapse_cols <- c(

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -68,13 +68,13 @@ check_annotation_values <- function(x, annotations, ...) {
 }
 
 #' @export
-#' @rdname check_annotation_values
+#' @describeIn check_annotation_values Return NULL
 check_annotation_values.NULL <- function(x, annotations, ...) {
   return(NULL)
 }
 
 #' @export
-#' @rdname check_annotation_values
+#' @describeIn check_annotation_values Check annotation values on a Synapse file
 check_annotation_values.synapseclient.entity.File <- function(x, annotations, syn, ...) { # nolint
   annots <- dict_to_list(syn$getAnnotations(x))
   check_values(
@@ -87,7 +87,7 @@ check_annotation_values.synapseclient.entity.File <- function(x, annotations, sy
 }
 
 #' @export
-#' @rdname check_annotation_values
+#' @describeIn check_annotation_values Check annotation values in a data frame
 check_annotation_values.data.frame <- function(x, annotations, ...) {
   check_values(
     x,
@@ -98,7 +98,7 @@ check_annotation_values.data.frame <- function(x, annotations, ...) {
 }
 
 #' @export
-#' @rdname check_annotation_values
+#' @describeIn check_annotation_values Check annotation values in a Synapse table
 check_annotation_values.synapseclient.table.CsvFileTable <- function(x, annotations, ...) { # nolint
   dat <- utils::read.csv(x$filepath, stringsAsFactors = FALSE, na.strings = "")
   fv_synapse_cols <- c(
@@ -152,13 +152,13 @@ valid_annotation_values <- function(x, annotations, ...) {
 }
 
 #' @export
-#' @rdname valid_annotation_values
+#' @describeIn valid_annotation_values Return NULL
 valid_annotation_values.NULL <- function(x, annotations, ...) {
   return(NULL)
 }
 
 #' @export
-#' @rdname valid_annotation_values
+#' @describeIn valid_annotation_values Valid annotation values on a Synapse file
 valid_annotation_values.synapseclient.entity.File <- function(x, annotations, syn, ...) { # nolint
   annots <- dict_to_list(syn$getAnnotations(x))
   check_values(
@@ -170,7 +170,7 @@ valid_annotation_values.synapseclient.entity.File <- function(x, annotations, sy
 }
 
 #' @export
-#' @rdname valid_annotation_values
+#' @describeIn valid_annotation_values Valid annotation values in a data frame
 valid_annotation_values.data.frame <- function(x, annotations, ...) {
   check_values(
     x,
@@ -181,7 +181,7 @@ valid_annotation_values.data.frame <- function(x, annotations, ...) {
 }
 
 #' @export
-#' @rdname valid_annotation_values
+#' @describeIn valid_annotation_values Valid annotation values in a Synapse table
 valid_annotation_values.synapseclient.table.CsvFileTable <- function(x, annotations, ...) { # nolint
   dat <- utils::read.csv(x$filepath, stringsAsFactors = FALSE)
   fv_synapse_cols <- c(

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -97,8 +97,10 @@ check_annotation_values.data.frame <- function(x, annotations, ...) {
   )
 }
 
+# nolint start
 #' @export
 #' @describeIn check_annotation_values Check annotation values in a Synapse table
+# nolint end
 check_annotation_values.synapseclient.table.CsvFileTable <- function(x, annotations, ...) { # nolint
   dat <- utils::read.csv(x$filepath, stringsAsFactors = FALSE, na.strings = "")
   fv_synapse_cols <- c(
@@ -180,8 +182,10 @@ valid_annotation_values.data.frame <- function(x, annotations, ...) {
   )
 }
 
+# nolint start
 #' @export
 #' @describeIn valid_annotation_values Valid annotation values in a Synapse table
+# nolint end
 valid_annotation_values.synapseclient.table.CsvFileTable <- function(x, annotations, ...) { # nolint
   dat <- utils::read.csv(x$filepath, stringsAsFactors = FALSE)
   fv_synapse_cols <- c(

--- a/man/check_annotation_keys.Rd
+++ b/man/check_annotation_keys.Rd
@@ -39,6 +39,17 @@ Checks that all annotation keys on a file, in a file view, or in a data frame
 are valid annotations. \code{check_annotation_keys()} returns any invalid
 annotation keys; \code{valid_annotation_keys()} returns \emph{valid} annotation keys.
 }
+\section{Methods (by class)}{
+\itemize{
+\item \code{NULL}: Return NULL
+
+\item \code{synapseclient.entity.File}: Check annotation keys in a Synapse file
+
+\item \code{data.frame}: Check annotation keys in a data frame
+
+\item \code{synapseclient.table.CsvFileTable}: Check annotation keys for a Synapse table
+}}
+
 \examples{
 annots <- data.frame(
   key = c("assay", "fileFormat", "fileFormat", "fileFormat", "species"),

--- a/man/check_annotation_values.Rd
+++ b/man/check_annotation_values.Rd
@@ -46,6 +46,17 @@ definition merely specifies a required type, then the values are checked
 against that type, with values that are coercible to the correct type treated
 as valid (see \code{\link[=can_coerce]{can_coerce()}}).
 }
+\section{Methods (by class)}{
+\itemize{
+\item \code{NULL}: Return NULL
+
+\item \code{synapseclient.entity.File}: Check annotation values on a Synapse file
+
+\item \code{data.frame}: Check annotation values in a data frame
+
+\item \code{synapseclient.table.CsvFileTable}: Check annotation values in a Synapse table
+}}
+
 \examples{
 annots <- data.frame(
   key = c("assay", "fileFormat", "fileFormat", "fileFormat", "species"),

--- a/man/valid_annotation_keys.Rd
+++ b/man/valid_annotation_keys.Rd
@@ -37,6 +37,17 @@ A vector of valid annotation keys present in \code{x}.
 Checks for and returns the valid annotation keys in a data framae, Synapse
 file, or Synapse file view.
 }
+\section{Methods (by class)}{
+\itemize{
+\item \code{NULL}: Return NULL
+
+\item \code{synapseclient.entity.File}: Valid annotation keys on a Synapse file
+
+\item \code{data.frame}: Valid annotation keys in a data frame
+
+\item \code{synapseclient.table.CsvFileTable}: Valid annotation keys in a Synapse table
+}}
+
 \examples{
 annots <- data.frame(
   key = c("assay", "fileFormat", "fileFormat", "fileFormat", "species"),

--- a/man/valid_annotation_values.Rd
+++ b/man/valid_annotation_values.Rd
@@ -37,6 +37,17 @@ A named list of valid annotation values.
 Checks for and returns the valid annotation valaues in a data frame, Synapse
 file, or Synapse file view.
 }
+\section{Methods (by class)}{
+\itemize{
+\item \code{NULL}: Return NULL
+
+\item \code{synapseclient.entity.File}: Valid annotation values on a Synapse file
+
+\item \code{data.frame}: Valid annotation values in a data frame
+
+\item \code{synapseclient.table.CsvFileTable}: Valid annotation values in a Synapse table
+}}
+
 \examples{
 annots <- data.frame(
   key = c("assay", "fileFormat", "fileFormat", "fileFormat", "species"),


### PR DESCRIPTION
As recommended in the roxygen2 documentation, `@describeIn` behaves similarly to `@rdname` but adds a section that also describes each method separately.