### PR TITLE
Remove unused packages from Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,6 @@ Depends:
     shinyBS
 Imports:
     config,
-    DT,
     ggplot2,
     glue,
     golem,
@@ -37,7 +36,6 @@ Imports:
     jsonvalidate,
     knitr,
     markdown,
-    pkgload,
     purrr,
     readr,
     readxl,


### PR DESCRIPTION
`rhub::check()` turned this up. I'm not sure why it doesn't create a note locally when I run `devtools::check()`, but regardless, these packages are no longer used in dccvalidator. DT has been completely removed, and pkgload is used in the `app.R` in this repo, but not in the dccvalidator package itself, so both should be removed from DESCRIPTION.