### PR TITLE
Update copyright info

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,10 @@ Authors@R:
       person(given = "Kelsey",
              family = "Montgomery",
              role = "aut",
-             email = "kelsey.montgomery@sagebase.org"))
+             email = "kelsey.montgomery@sagebase.org"),
+      person(given = "Dean",
+             family = "Attali",
+             role = "cph"))
 Description: Performs checks for common metadata quality issues. Used by the
     data coordinating centers for the 'AMP-AD' consortium
     (<https://adknowledgeportal.synapse.org>), 'PsychENCODE' consortium

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-YEAR: 2018
+YEAR: 2020
 COPYRIGHT HOLDER: Sage Bionetworks


### PR DESCRIPTION
- Updates copyright year to 2020
- Adds Dean Attali as a copyright holder in DESCRIPTION, since we are redistributing his module under MIT license