### PR TITLE
Coerce logical

### DIFF
--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -332,14 +332,9 @@ can_coerce <- function(values, class) {
     return(TRUE)
   }
 
-  ## Convert factors to strings
-  if (inherits(values, "factor")) {
-    values <- as.character(values)
-  }
-
   if (class == "character" &
     (inherits(values, "numeric") | inherits(values, "integer") |
-      inherits(values, "logical"))) {
+      inherits(values, "logical") | inherits(values, "factor"))) {
     return(TRUE)
   } else if (class == "numeric" & inherits(values, "integer")) {
     return(TRUE)

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -326,12 +326,18 @@ check_type <- function(values, key, annotations, whitelist_values = NULL,
 #' can_coerce(2.5, "integer")
 #' }
 can_coerce <- function(values, class) {
-  if (class == "character" &
   ## If the values are already the correct class, then obviously the answer
   ## should be yes
   if (inherits(values, class)) {
     return(TRUE)
-  } else if (class == "character" &
+  }
+
+  ## Convert factors to strings
+  if (inherits(values, "factor")) {
+    values <- as.character(values)
+  }
+
+  if (class == "character" &
     (inherits(values, "numeric") | inherits(values, "integer") |
       inherits(values, "logical"))) {
     return(TRUE)

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -287,14 +287,19 @@ check_type <- function(values, key, annotations, whitelist_values = NULL,
 #' in R's built-in coercion functions (e.g. `as.numeric()` warns when it
 #' introduces NAs but `as.logical()` doesn't; `as.integer()` will silently
 #' remove decimal places from numeric inputs) we check only for the specific
-#' coercions we want to allow, currently: numeric, integer, or logical to string
+#' coercions we want to allow, primarily allowing numeric, integer, or logical
+#' values to be considered valid even when the required type is character.
 #'
 #' This function is mainly in place so that we can automatically allow numeric
 #' read lengths, pH values, etc., which are defined as strings in our annotation
 #' vocabulary but can reasonably be numbers.
 #'
-#' This function will also return `TRUE` if the values are integers and the
-#' desired class is numeric.
+#' Additionally, this function will return `TRUE` if the values are integers and
+#' the desired class is numeric.
+#'
+#' It will also allow the following capitalizations of boolean values: true,
+#' True, TRUE, false, False, FALSE. These are all treated as valid booleans by
+#' Synapse.
 #'
 #' This function will *not* affect validation of enumerated values, regardless
 #' of their class. It is only used when validating annotations that have a
@@ -327,6 +332,12 @@ can_coerce <- function(values, class) {
     return(TRUE)
   } else if (class == "numeric" & inherits(values, "integer")) {
     return(TRUE)
+  } else if (class == "logical") {
+    if (all(values %in% c("true", "True", "TRUE", "false", "False", "FALSE"))) {
+      return(TRUE)
+    } else {
+      return(FALSE)
+    }
   } else {
     return(FALSE)
   }

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -327,6 +327,11 @@ check_type <- function(values, key, annotations, whitelist_values = NULL,
 #' }
 can_coerce <- function(values, class) {
   if (class == "character" &
+  ## If the values are already the correct class, then obviously the answer
+  ## should be yes
+  if (inherits(values, class)) {
+    return(TRUE)
+  } else if (class == "character" &
     (inherits(values, "numeric") | inherits(values, "integer") |
       inherits(values, "logical"))) {
     return(TRUE)

--- a/man/can_coerce.Rd
+++ b/man/can_coerce.Rd
@@ -20,15 +20,20 @@ Checks if values are coercible to a given class. Because of inconsistencies
 in R's built-in coercion functions (e.g. \code{as.numeric()} warns when it
 introduces NAs but \code{as.logical()} doesn't; \code{as.integer()} will silently
 remove decimal places from numeric inputs) we check only for the specific
-coercions we want to allow, currently: numeric, integer, or logical to string
+coercions we want to allow, primarily allowing numeric, integer, or logical
+values to be considered valid even when the required type is character.
 }
 \details{
 This function is mainly in place so that we can automatically allow numeric
 read lengths, pH values, etc., which are defined as strings in our annotation
 vocabulary but can reasonably be numbers.
 
-This function will also return \code{TRUE} if the values are integers and the
-desired class is numeric.
+Additionally, this function will return \code{TRUE} if the values are integers and
+the desired class is numeric.
+
+It will also allow the following capitalizations of boolean values: true,
+True, TRUE, false, False, FALSE. These are all treated as valid booleans by
+Synapse.
 
 This function will \emph{not} affect validation of enumerated values, regardless
 of their class. It is only used when validating annotations that have a

--- a/tests/testthat/test-check-annotation-values.R
+++ b/tests/testthat/test-check-annotation-values.R
@@ -424,3 +424,24 @@ test_that("can_coerce() returns FALSE if values aren't coercible", {
   expect_false(can_coerce("a", "logical"))
   expect_false(can_coerce(2.1, "integer"))
 })
+
+test_that("can_coerce() returns TRUE for any capitalization of true/false", {
+  expect_true(can_coerce("true", "logical"))
+  expect_true(can_coerce("True", "logical"))
+  expect_true(can_coerce("TRUE", "logical"))
+  expect_true(can_coerce(TRUE, "logical"))
+  expect_true(can_coerce("false", "logical"))
+  expect_true(can_coerce("False", "logical"))
+  expect_true(can_coerce("FALSE", "logical"))
+  expect_true(can_coerce(FALSE, "logical"))
+})
+
+test_that("can_coerce() returns FALSE for values that aren't true/false", {
+  expect_false(can_coerce("foo", "logical"))
+  expect_false(can_coerce("T", "logical"))
+  expect_false(can_coerce("F", "logical"))
+  expect_false(can_coerce(c("foo", "True"), "logical"))
+  expect_false(can_coerce(c("foo", "True", "FALSE"), "logical"))
+  expect_false(can_coerce(1, "logical"))
+  expect_false(can_coerce(0, "logical"))
+})

--- a/tests/testthat/test-check-annotation-values.R
+++ b/tests/testthat/test-check-annotation-values.R
@@ -455,7 +455,6 @@ test_that("a value can be coerced to its own type", {
 })
 
 test_that("factors are converted to string before checking coercibility", {
-  can_coerce(factor("TRUE"), "logical")
-  can_coerce(factor("foo"), "character")
-  can_coerce("foo", "character")
+  expect_true(can_coerce(factor("TRUE"), "logical"))
+  expect_true(can_coerce(factor("foo"), "character"))
 })

--- a/tests/testthat/test-check-annotation-values.R
+++ b/tests/testthat/test-check-annotation-values.R
@@ -454,3 +454,8 @@ test_that("a value can be coerced to its own type", {
   expect_true(can_coerce(factor("foo"), "factor"))
 })
 
+test_that("factors are converted to string before checking coercibility", {
+  can_coerce(factor("TRUE"), "logical")
+  can_coerce(factor("foo"), "character")
+  can_coerce("foo", "character")
+})

--- a/tests/testthat/test-check-annotation-values.R
+++ b/tests/testthat/test-check-annotation-values.R
@@ -445,3 +445,12 @@ test_that("can_coerce() returns FALSE for values that aren't true/false", {
   expect_false(can_coerce(1, "logical"))
   expect_false(can_coerce(0, "logical"))
 })
+
+test_that("a value can be coerced to its own type", {
+  expect_true(can_coerce(1L, "integer"))
+  expect_true(can_coerce(1, "numeric"))
+  expect_true(can_coerce("foo", "character"))
+  expect_true(can_coerce(TRUE, "logical"))
+  expect_true(can_coerce(factor("foo"), "factor"))
+})
+


### PR DESCRIPTION
Fixes #276 

Changes proposed in this pull request:

- Ensures that `true`, `True`, `TRUE`, `false`, `False`, `FALSE` are all treated as coercible to logical values. While working on this, I noticed a couple small bugs with the function as it was written and fixed those as well.

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: yes
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: NA
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: NA
