### PR TITLE
update upload instructions

### DIFF
--- a/inst/using-the-dccvalidator-pec.Rmd
+++ b/inst/using-the-dccvalidator-pec.Rmd
@@ -109,7 +109,7 @@ The [Data Analysis Core](https://www.synapse.org/#!Synapse:syn20959298) will rep
   
 ## Uploading data to Synapse after validation
 
-Once data has passed validation, and the PEC data curators permit edit permissions to the **Staging** folder, you will use your newly created manifest file to upload data using `syncToSynapse`. You can execute `synToSynapse` in the [Python client](https://python-docs.synapse.org/build/html/synapseutils.html#synapseutils.sync.syncToSynapse) and [R client](https://github.com/Sage-Bionetworks/synapserutils#upload-data-in-bulk). For getting started with the Synapse programmatic clients, please visit our [Synapse docs](https://docs.synapse.org/articles/api_documentation.html).
+Once data has passed validation, and the PEC data curators permit edit permissions to the **Staging** folder, you will use your newly created manifest file to upload data using `syncToSynapse`. You can execute `syncToSynapse` in the [Python client](https://python-docs.synapse.org/build/html/synapseutils.html#synapseutils.sync.syncToSynapse) and [R client](https://github.com/Sage-Bionetworks/synapserutils#upload-data-in-bulk). For getting started with the Synapse programmatic clients, please visit our [Synapse docs](https://docs.synapse.org/articles/api_documentation.html).
 
 ## Data Release
 

--- a/inst/using-the-dccvalidator-pec.Rmd
+++ b/inst/using-the-dccvalidator-pec.Rmd
@@ -109,7 +109,7 @@ The [Data Analysis Core](https://www.synapse.org/#!Synapse:syn20959298) will rep
   
 ## Uploading data to Synapse after validation
 
-Once data has passed validation and the PEC data curators permit edit permissions to the **Staging** folder, data may be uploaded. Bulk file upload is achievable using the [web UI](https://docs.synapse.org/articles/files_and_versioning.html) or the [R, Python and command line clients](https://docs.synapse.org/articles/uploading_in_bulk.html).
+Once data has passed validation, and the PEC data curators permit edit permissions to the **Staging** folder, you will use your newly created manifest file to upload data using `syncToSynapse`. You can execute `synToSynapse` in the [Python client](https://python-docs.synapse.org/build/html/synapseutils.html#synapseutils.sync.syncToSynapse) and [R client](https://github.com/Sage-Bionetworks/synapserutils#upload-data-in-bulk). For getting started with the Synapse programmatic clients, please visit our [Synapse docs](https://docs.synapse.org/articles/api_documentation.html).
 
 ## Data Release
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Update instructions to clarify that only the manifest can be used to upload! I expect to push another update when I can test using the command line with `synctosynapse` but this change is pertinent to some collaborators uploading data in the short term. 

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: NA
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`:NA
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`:NA
