### PR TITLE
Prevent uploading manifest as .csv

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -187,6 +187,10 @@ app_server <- function(input, output, session) {
               !is.null(manifest())
             ),
             message = "Please upload some data to validate"
+          ),
+          need(
+            tolower(tools::file_ext(input$manifest$name)) != "csv",
+            "Manifest file must be .tsv or .txt, not .csv"
           )
         )
 


### PR DESCRIPTION
Fixes #271. If the user tries to upload a manifest file whose extension is .csv, they will see an error prompting them to upload a .tsv or .txt.