### PR TITLE
Add new team that can validate data in AMP-AD

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -46,6 +46,7 @@ amp-ad:
   annotations_link: "https://shinypro.synapse.org/users/kwoo/amp-ad-metadata-dictionary/"
   teams:
     - "3320424"
+    - "3405451"
   study_link_ref: "https://adknowledgeportal.synapse.org/#/DataAccess/AcknowledgementStatements"
   templates:
     assay_templates:

--- a/inst/app/create_project.R
+++ b/inst/app/create_project.R
@@ -47,3 +47,10 @@ syn$setPermissions(
   principalId = "3320424",
   accessType = list("CREATE", "READ", "UPDATE")
 )
+
+## Give AD_PortalContributor team CREATE, UPDATE, and READ
+syn$setPermissions(
+  entity = new_proj_id$properties$id,
+  principalId = "3405451",
+  accessType = list("CREATE", "READ", "UPDATE")
+)


### PR DESCRIPTION
Fixes #285 

I've added the team to the project and the config file. This should allow members of the AD_PortalContributor team to use the app.