### PR TITLE
Fix data_summary() bug and add test

### DIFF
--- a/R/mod-file-summary.R
+++ b/R/mod-file-summary.R
@@ -179,10 +179,10 @@ data_summary <- function(data) {
   for (var in data_sum$skim_variable) {
     var_col <- which(names(data) == var)
     val_summary <- summarize_values(data[[var_col]])
-    if(!is.null(val_summary) && length(val_summary) > 0) {
+    if (!is.null(val_summary) && length(val_summary) > 0) {
       data_sum$value_occurrence[data_sum$skim_variable == var] <- val_summary
     } else {
-      data_sum$value_occurrence[data_sum$skim_variable == var] <-NA
+      data_sum$value_occurrence[data_sum$skim_variable == var] <- NA
     }
   }
   data_sum

--- a/R/mod-file-summary.R
+++ b/R/mod-file-summary.R
@@ -179,11 +179,7 @@ data_summary <- function(data) {
   for (var in data_sum$skim_variable) {
     var_col <- which(names(data) == var)
     val_summary <- summarize_values(data[[var_col]])
-    if (!is.null(val_summary) && length(val_summary) > 0) {
-      data_sum$value_occurrence[data_sum$skim_variable == var] <- val_summary
-    } else {
-      data_sum$value_occurrence[data_sum$skim_variable == var] <- NA
-    }
+    data_sum$value_occurrence[data_sum$skim_variable == var] <- val_summary
   }
   data_sum
 }
@@ -199,8 +195,10 @@ data_summary <- function(data) {
 #'   where the value is given with the number of
 #'   occurrences in parenthesis.
 summarize_values <- function(values) {
-  if (is.null(values)) {
-    return(NULL)
+  if (all(purrr::map_lgl(values, function(x) {
+    is.na(x) || is.null(x)}))
+  ) {
+    return(NA)
   }
   glue::glue_collapse(
     purrr::imap_chr(table(values), ~ glue::glue("{.y} ({.x})")),
@@ -296,7 +294,7 @@ get_column_definitions <- function(data) {
   columns$value_occurrence <- reactable::colDef(
     name = "Value (# Occurrences)",
     cell = function(value) {
-      if (nchar(value) > 40) {
+      if (!is.na(value) && nchar(value) > 40) {
         return(glue::glue("{substr(value, 1, 40)}..."))
       } else {
         return(value)
@@ -304,7 +302,7 @@ get_column_definitions <- function(data) {
     },
     details = function(index) {
       value <- data[index, "value_occurrence"]
-      if (nchar(value) > 40) {
+      if (!is.na(value) && nchar(value) > 40) {
         return(htmltools::div(
           shinydashboardPlus::boxPad(
             br(),

--- a/R/mod-file-summary.R
+++ b/R/mod-file-summary.R
@@ -178,8 +178,12 @@ data_summary <- function(data) {
   data_sum <- tibble::add_column(data_sum, value_occurrence = NA)
   for (var in data_sum$skim_variable) {
     var_col <- which(names(data) == var)
-    data_sum$value_occurrence[data_sum$skim_variable == var] <-
-      summarize_values(data[[var_col]])
+    val_summary <- summarize_values(data[[var_col]])
+    if(!is.null(val_summary) && length(val_summary) > 0) {
+      data_sum$value_occurrence[data_sum$skim_variable == var] <- val_summary
+    } else {
+      data_sum$value_occurrence[data_sum$skim_variable == var] <-NA
+    }
   }
   data_sum
 }

--- a/tests/testthat/test-mod-file-summary-helpers.R
+++ b/tests/testthat/test-mod-file-summary-helpers.R
@@ -83,7 +83,7 @@ test_that("data_summary keeps only desired, existing columns", {
   expect_true(all(names(res3 %in% desired_cols)))
 })
 
-test_that("data_summary doesn't fail if column is empty", {
+test_that("data_summary returns NA if column is empty", {
   dat1 <- tibble::tribble(
     ~col1, ~col2, ~col3,
     "a", NULL, "b",
@@ -94,10 +94,34 @@ test_that("data_summary doesn't fail if column is empty", {
     "a", NA, "b",
     "c", NA, "d"
   )
+  dat3 <- tibble::tribble(
+    ~col1, ~col2, ~col3,
+    "a", NULL, "b"
+  )
+  dat4 <- tibble::tribble(
+    ~col1, ~col2, ~col3,
+    "a", NA, "b"
+  )
   res1 <- data_summary(dat1)
   res2 <- data_summary(dat2)
-  expect_true(inherits(res1, "tbl_df"))
-  expect_true(inherits(res2, "tbl_df"))
+  res3 <- data_summary(dat3)
+  res4 <- data_summary(dat4)
+  expect_equal(
+    res1$value_occurrence[res1$skim_variable == "col2"],
+    as.character(NA)
+  )
+  expect_equal(
+    res2$value_occurrence[res2$skim_variable == "col2"],
+    as.character(NA)
+  )
+  expect_equal(
+    res3$value_occurrence[res3$skim_variable == "col2"],
+    as.character(NA)
+  )
+  expect_equal(
+    res4$value_occurrence[res4$skim_variable == "col2"],
+    as.character(NA)
+  )
 })
 
 test_that("summarize_values returns string summary", {
@@ -115,9 +139,15 @@ test_that("summarize_values returns string summary", {
   expect_equal(res4, "1 (2), 2 (2)")
 })
 
-test_that("summarize_values returns NULL if values = NULL", {
-  res <- summarize_values(NULL)
-  expect_null(res)
+test_that("summarize_values returns NA if values are all NULL or NA", {
+  res1 <- summarize_values(NULL)
+  res2 <- summarize_values(NA)
+  res3 <- summarize_values(list(NULL, NULL, NULL))
+  res4 <- summarize_values(list(NA, NA, NA))
+  expect_equal(res1, NA)
+  expect_equal(res2, NA)
+  expect_equal(res3, NA)
+  expect_equal(res4, NA)
 })
 
 test_that("get_column_definitions returns list of column definitions", {

--- a/tests/testthat/test-mod-file-summary-helpers.R
+++ b/tests/testthat/test-mod-file-summary-helpers.R
@@ -83,6 +83,23 @@ test_that("data_summary keeps only desired, existing columns", {
   expect_true(all(names(res3 %in% desired_cols)))
 })
 
+test_that("data_summary doesn't fail if column is empty", {
+  dat1 <- tibble::tribble(
+    ~col1, ~col2, ~col3,
+    "a", NULL, "b",
+    "c", NULL, "d"
+  )
+  dat2 <- tibble::tribble(
+    ~col1, ~col2, ~col3,
+    "a", NA, "b",
+    "c", NA, "d"
+  )
+  res1 <- data_summary(dat1)
+  res2 <- data_summary(dat2)
+  expect_true(inherits(res1, "tbl_df"))
+  expect_true(inherits(res2, "tbl_df"))
+})
+
 test_that("summarize_values returns string summary", {
   val1 <- c("a", "a", "a")
   val2 <- c("a", "b", "b")


### PR DESCRIPTION
Fixes #288.

Changes proposed in this pull request:

- Fix the `data_summary()` bug where empty columns resulted in an error
- Add tests

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: yes
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: N/A
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: N/A
