### PR TITLE
Basename bug

### DIFF
--- a/R/check-files-manifest.R
+++ b/R/check-files-manifest.R
@@ -48,7 +48,11 @@ check_files_manifest <- function(manifest, filenames, strict = FALSE,
   behavior <- glue::glue(
     "The following files should be present in the manifest: {names_collapsed}. However, if this is an update to an existing study and the files have not changed since they were last released, this warning can be ignored." # nolint
   )
-  missing <- setdiff(filenames, basename(manifest$path))
+  if (all(is.na(manifest$path))) {
+    missing <- filenames
+  } else {
+    missing <- setdiff(filenames, basename(manifest$path))
+  }
   if (length(missing) > 0) {
     check_condition(
       msg = fail_msg,

--- a/tests/testthat/test-check-files-manifest.R
+++ b/tests/testthat/test-check-files-manifest.R
@@ -89,3 +89,10 @@ test_that("manifest can have full paths", {
   expect_true(inherits(res1, "check_pass"))
   expect_true(inherits(res2, "check_warn"))
 })
+
+test_that("check_files_manifest returns all filenames if path is empty", {
+  manifest <- tibble::tibble(path = c(NA, NA, NA))
+  res <- check_files_manifest(manifest, "file.csv")
+  expect_true(inherits(res, "check_warn"))
+  expect_equal(res$data, "file.csv")
+})


### PR DESCRIPTION
Fixes # ...I'm not sure. I know we had this as an issue before, but I can't seem to find it. There's a problem in dccmonitor where someone uploaded a file that has an empty path column. The app was crashing due to the basename function in `check_files_manifest()` getting `NA` values.

Changes proposed in this pull request:

- Checks if the manifest column 'path' is empty (i.e. all `NA`). If so, returns warning with all the given file names as missing.
- Adds test for this behavior.

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: yes
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: n/a
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: n/a
