### PR TITLE
Treat whole numbers as coercible to integer

### DIFF
--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -295,7 +295,9 @@ check_type <- function(values, key, annotations, whitelist_values = NULL,
 #' vocabulary but can reasonably be numbers.
 #'
 #' Additionally, this function will return `TRUE` if the values are integers and
-#' the desired class is numeric.
+#' the desired class is numeric, and will return `TRUE` if the values are
+#' numeric but are whole numbers. `2.0` is considered coercible to integer, but
+#' `2.1` is not.
 #'
 #' It will also allow the following capitalizations of boolean values: true,
 #' True, TRUE, false, False, FALSE. These are all treated as valid booleans by
@@ -319,6 +321,7 @@ check_type <- function(values, key, annotations, whitelist_values = NULL,
 #' can_coerce(TRUE, "character")
 #' can_coerce(1L, "character")
 #' can_coerce(1L, "numeric")
+#' can_coerce(1.0, "integer")
 #'
 #' # Not coercible:
 #' can_coerce("foo", "numeric")
@@ -332,14 +335,21 @@ can_coerce <- function(values, class) {
     return(TRUE)
   }
 
-  if (class == "character" &
+  if (class == "character" &&
     (inherits(values, "numeric") | inherits(values, "integer") |
       inherits(values, "logical") | inherits(values, "factor"))) {
+    ## Anything is coercible to character
     return(TRUE)
-  } else if (class == "numeric" & inherits(values, "integer")) {
+  } else if (class == "numeric" && inherits(values, "integer")) {
+    ## Integers are coercible to numeric
+    return(TRUE)
+  } else if (class == "integer" && inherits(values, "numeric") &&
+               isTRUE(all.equal(values, as.integer(values)))) {
+    ## Whole numbers are coercible to integers
     return(TRUE)
   } else if (class == "logical") {
     if (all(values %in% c("true", "True", "TRUE", "false", "False", "FALSE"))) {
+      ## All capitalizations of logicals are valid
       return(TRUE)
     } else {
       return(FALSE)

--- a/man/can_coerce.Rd
+++ b/man/can_coerce.Rd
@@ -29,7 +29,9 @@ read lengths, pH values, etc., which are defined as strings in our annotation
 vocabulary but can reasonably be numbers.
 
 Additionally, this function will return \code{TRUE} if the values are integers and
-the desired class is numeric.
+the desired class is numeric, and will return \code{TRUE} if the values are
+numeric but are whole numbers. \code{2.0} is considered coercible to integer, but
+\code{2.1} is not.
 
 It will also allow the following capitalizations of boolean values: true,
 True, TRUE, false, False, FALSE. These are all treated as valid booleans by
@@ -47,6 +49,7 @@ can_coerce(1, "character")
 can_coerce(TRUE, "character")
 can_coerce(1L, "character")
 can_coerce(1L, "numeric")
+can_coerce(1.0, "integer")
 
 # Not coercible:
 can_coerce("foo", "numeric")

--- a/tests/testthat/test-check-annotation-values.R
+++ b/tests/testthat/test-check-annotation-values.R
@@ -464,3 +464,10 @@ test_that("factors are converted to string before checking coercibility", {
   expect_true(can_coerce(factor("TRUE"), "logical"))
   expect_true(can_coerce(factor("foo"), "character"))
 })
+
+test_that("whole numbers that aren't integer type are considered coercible", {
+  expect_true(can_coerce(1.0, "integer"))
+  expect_true(can_coerce(2.0, "integer"))
+  expect_true(can_coerce(c(1.0, 2.0), "integer"))
+  expect_false(can_coerce(c(1.0, 2.5), "integer"))
+})


### PR DESCRIPTION
Fixes #300 

Changes proposed in this pull request:

- Treats whole numbers as coercible to integer.

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: yes
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: NA
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: NA
