### PR TITLE
Reduce imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,8 +36,6 @@ Imports:
     glue,
     golem,
     htmltools,
-    jsonlite,
-    jsonvalidate,
     knitr,
     markdown,
     purrr,
@@ -58,6 +56,8 @@ Imports:
     visdat
 Suggests:
     covr,
+    jsonlite,
+    jsonvalidate,
     rmarkdown (>= 1.16.2),
     stringr,
     testthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,6 @@ Imports:
     shinyjs,
     skimr,
     stats,
-    stringr,
     tibble,
     tools,
     utils,
@@ -60,6 +59,7 @@ Imports:
 Suggests:
     covr,
     rmarkdown (>= 1.16.2),
+    stringr,
     testthat,
     withr
 VignetteBuilder:

--- a/R/check-name.R
+++ b/R/check-name.R
@@ -17,11 +17,7 @@ is_name_valid <- function(name) {
     valid <- FALSE
   } else {
     # Check if study name has inappropriate characters
-    temp_string <- stringr::str_replace_all(
-      name,
-      " |\\.|_|-|\\+|\\(|\\)",
-      ""
-    )
+    temp_string <- gsub(" |\\.|_|-|\\+|\\(|\\)", "", name)
     if (grepl("[[:punct:]]", temp_string)) {
       valid <- FALSE
     }

--- a/R/check-schema-df.R
+++ b/R/check-schema-df.R
@@ -9,6 +9,8 @@
 #'   schema.
 #' @export
 #' @examples
+#' if (requireNamespace("jsonvalidate", quietly = TRUE) &
+#'       requireNamespace("jsonlite", quietly = TRUE)) {
 #' dat <- data.frame(
 #'   x = c(NA, 1, NA),
 #'   y = c(NA, NA, "foo")
@@ -27,9 +29,16 @@
 #' }
 #' '
 #' check_schema_df(dat, schema)
+#' }
 check_schema_df <- function(df, schema,
                             success_msg = "Data is valid against the schema",
                             fail_msg = "Data is invalid against the schema") {
+  if (!requireNamespace("jsonvalidate", quietly = TRUE)) {
+    stop(
+      "Package \"jsonvalidate\" needed for this function to work. Please install it.",
+      call. = FALSE
+    )
+  }
   json_list <- df_to_json_list(df)
   results <- purrr::map(json_list, function(x) {
     jsonvalidate::json_validate(

--- a/R/check-schema-df.R
+++ b/R/check-schema-df.R
@@ -35,7 +35,7 @@ check_schema_df <- function(df, schema,
                             fail_msg = "Data is invalid against the schema") {
   if (!requireNamespace("jsonvalidate", quietly = TRUE)) {
     stop(
-      "Package \"jsonvalidate\" needed for this function to work. Please install it.",
+      "Package \"jsonvalidate\" needed for this function to work. Please install it.", # nolint
       call. = FALSE
     )
   }

--- a/R/check-schema-json.R
+++ b/R/check-schema-json.R
@@ -8,6 +8,7 @@
 #'   schema.
 #' @export
 #' @examples
+#' if (requireNamespace("jsonvalidate", quietly = TRUE)) {
 #' schema <- '{
 #'   "$schema": "http://json-schema.org/draft-04/schema#",
 #'   "properties": {
@@ -26,9 +27,16 @@
 #' }'
 #' check_schema_json(json_valid, schema)
 #' check_schema_json(json_invalid, schema)
+#' }
 check_schema_json <- function(json, schema,
                               success_msg = "Data is valid against the schema",
                               fail_msg = "Data is invalid against the schema") {
+  if (!requireNamespace("jsonvalidate", quietly = TRUE)) {
+    stop(
+      "Package \"jsonvalidate\" needed for this function to work. Please install it.",
+      call. = FALSE
+    )
+  }
   result <- suppressWarnings(
     # (using suppressWarnings to avoid warning about "schema $id ignored")
     jsonvalidate::json_validate(

--- a/R/check-schema-json.R
+++ b/R/check-schema-json.R
@@ -33,7 +33,7 @@ check_schema_json <- function(json, schema,
                               fail_msg = "Data is invalid against the schema") {
   if (!requireNamespace("jsonvalidate", quietly = TRUE)) {
     stop(
-      "Package \"jsonvalidate\" needed for this function to work. Please install it.",
+      "Package \"jsonvalidate\" needed for this function to work. Please install it.", # nolint
       call. = FALSE
     )
   }

--- a/R/df-to-json.R
+++ b/R/df-to-json.R
@@ -18,7 +18,7 @@
 df_to_json_list <- function(df) {
   if (!requireNamespace("jsonlite", quietly = TRUE)) {
     stop(
-      "Package \"jsonlite\" needed for this function to work. Please install it.",
+      "Package \"jsonlite\" needed for this function to work. Please install it.", # nolint
       call. = FALSE
     )
   }

--- a/R/df-to-json.R
+++ b/R/df-to-json.R
@@ -9,11 +9,19 @@
 #' @export
 #' @seealso check_schema
 #' @examples
+#' if (requireNamespace("jsonlite", quietly = TRUE)) {
 #' dat <- data.frame(
 #'   x = c(NA, 1L)
 #' )
 #' df_to_json_list(dat)
+#' }
 df_to_json_list <- function(df) {
+  if (!requireNamespace("jsonlite", quietly = TRUE)) {
+    stop(
+      "Package \"jsonlite\" needed for this function to work. Please install it.",
+      call. = FALSE
+    )
+  }
   result <- vector("list", nrow(df))
   for (i in seq_len(nrow(df))) {
     result[[i]] <- jsonlite::toJSON(jsonlite::unbox(df[i, , drop = FALSE]))

--- a/man/check_schema_df.Rd
+++ b/man/check_schema_df.Rd
@@ -30,6 +30,8 @@ Each row of the data frame will be converted to JSON and validated against
 the given schema.
 }
 \examples{
+if (requireNamespace("jsonvalidate", quietly = TRUE) &
+      requireNamespace("jsonlite", quietly = TRUE)) {
 dat <- data.frame(
   x = c(NA, 1, NA),
   y = c(NA, NA, "foo")
@@ -48,4 +50,5 @@ schema <- '{
 }
 '
 check_schema_df(dat, schema)
+}
 }

--- a/man/check_schema_json.Rd
+++ b/man/check_schema_json.Rd
@@ -30,6 +30,7 @@ schema.
 Check a JSON blob against a JSON Schema.
 }
 \examples{
+if (requireNamespace("jsonvalidate", quietly = TRUE)) {
 schema <- '{
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
@@ -48,4 +49,5 @@ json_invalid <- '{
 }'
 check_schema_json(json_valid, schema)
 check_schema_json(json_invalid, schema)
+}
 }

--- a/man/df_to_json_list.Rd
+++ b/man/df_to_json_list.Rd
@@ -18,10 +18,12 @@ in a list, to make it easier to iteratively validate data with
 \code{\link[=check_schema_df]{check_schema_df()}}.
 }
 \examples{
+if (requireNamespace("jsonlite", quietly = TRUE)) {
 dat <- data.frame(
   x = c(NA, 1L)
 )
 df_to_json_list(dat)
+}
 }
 \seealso{
 check_schema


### PR DESCRIPTION
Fixes #306 

Changes proposed in this pull request:

- Moves stringr, jsonlite, and jsonvalidate to Suggests
- Functions for validating against json schema throw an error if jsonlite/jsonvalidate are not available

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: NA
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: NA
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: NA

@Aryllen feel free to either add changes to our use of shinydashboardPlus to this PR, or open a separate one.