### PR TITLE
Remove need for shinydashboardPlus

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,6 @@ Imports:
     rlang,
     shiny,
     shinydashboard,
-    shinydashboardPlus,
     shinyjs,
     skimr,
     stats,

--- a/R/mod-file-summary.R
+++ b/R/mod-file-summary.R
@@ -196,7 +196,8 @@ data_summary <- function(data) {
 #'   occurrences in parenthesis.
 summarize_values <- function(values) {
   if (all(purrr::map_lgl(values, function(x) {
-    is.na(x) || is.null(x)}))
+    is.na(x) || is.null(x)
+  }))
   ) {
     return(NA)
   }
@@ -304,14 +305,9 @@ get_column_definitions <- function(data) {
       value <- data[index, "value_occurrence"]
       if (!is.na(value) && nchar(value) > 40) {
         return(htmltools::div(
-          shinydashboardPlus::boxPad(
-            br(),
-            glue::glue("{value[[1]]}"),
-            br(),
-            br(),
-            width = 12,
-            color = "blue"
-          )
+          glue::glue("{value[[1]]}"),
+          width = 12,
+          class = "detailbox"
         ))
       } else {
         return(NULL)

--- a/inst/app/www/custom.css
+++ b/inst/app/www/custom.css
@@ -42,3 +42,10 @@ summary {
 img {
   max-width: 100%;
 }
+
+/* Used in file summary mod */
+.detailbox {
+  color: #FFFFFF;
+  background-color: #367FA8;
+  padding: 3%;
+}

--- a/renv.lock
+++ b/renv.lock
@@ -782,13 +782,6 @@
       "Repository": "CRAN",
       "Hash": "12f87658587a6ea64a67e7d559d6491d"
     },
-    "shinydashboardPlus": {
-      "Package": "shinydashboardPlus",
-      "Version": "0.7.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "0d76b9a82ab3a31baf578d7da887205a"
-    },
     "shinyjs": {
       "Package": "shinyjs",
       "Version": "1.0.1.9006",


### PR DESCRIPTION
Fixes #306 (partly).

Changes proposed in this pull request:

- Change file summary module table to use custom css with a class labeled div for the details dropdown.
- Remove shinydashboardPlus from description and lock file.
- Adds the custom css to the css file.

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: N/A
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: N/A
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: N/A
