### PR TITLE
Add more documentation of how to use dccvalidator for other projects

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -31,6 +31,11 @@ reference:
     - check_specimen_ids_dup
     - check_schema_json
     - check_schema_df
+
+- title: Validation helpers
+  desc: >
+    Functions used by the data validation functions above.
+  contents:
     - get_synapse_annotations
     - get_synapse_table
     - get_template
@@ -60,7 +65,7 @@ reference:
     - check_certified_user
     - check_team_membership
 
-- title: Validation helpers
+- title: Constructors for validation results
   desc: >
     These functions generate custom conditions for reporting check failures,
     warnings, and successes.

--- a/inst/extdata/test_assay.csv
+++ b/inst/extdata/test_assay.csv
@@ -1,0 +1,7 @@
+﻿specimenID,assay,platform,RIN,libraryBatch,sequencingBatch,libraryPrep,libraryPreparationMethod,isStranded,runType,readLength
+a1,rnaSeq,HiSeq3000,,,,,,True,,75
+a2,rnaSeq,HiSeq3000,,,,,,True,,75
+b1,rnaSeq,HiSeq3000,,,,,,True,,100
+b2,rnaSeq,HiSeq3000,,,,,,,,100
+c1,rnaSeq,HiSeq3000,,,,,,True,,100
+d1,rnaSeq,HiSeq3000,,,,,,True,,100

--- a/inst/extdata/test_biospecimen.csv
+++ b/inst/extdata/test_biospecimen.csv
@@ -1,0 +1,8 @@
+﻿individualID,specimenID,specimenIdSource,samplingDate,organ,tissue,BrodmannArea,sampleStatus,tissueWeight,tissueVolume,nucleicAcidSource,cellType,fastingState
+P01,a1,,,brain,whole brain,,,,,bulk cell,cool cell,
+P01,a2,,,brain,whole brain,,,,,bulk cell,boring cell,
+P02,b1,,,brain,whole brain,,,,,bulk cell,fancy cell,
+P02,b2,,,brain,whole brain,,,,,bulk cell,cool cell,
+P03,c1,JAX,,brain,whole brain,,,,,bulk cell,boring cell,
+P04,d1,JAX,,brain,whole brain,,,,,bulk cell,fancy cell,
+P06,f1,JAX,,brain,whole brain,,,,,bulk cell,cool cell,

--- a/inst/extdata/test_individual.csv
+++ b/inst/extdata/test_individual.csv
@@ -1,0 +1,6 @@
+﻿individualID,individualIdSource,species,sex,genotype,genotypeBackground,room,litter,matingID,dateBirth,dateDeath,treatmentType
+P01,,Mouse,female,,,,,,5/6/19,,
+P02,,Mouse,male,,,,,,5/12/19,,
+P03,JAX,Mouse,male,,,,,,5/6/19,,
+P04,JAX,Mouse,female,,,,,,5/12/19,,
+P05,JAX,Mouse,female,,,,,,5/14/19,,

--- a/inst/extdata/test_manifest.txt
+++ b/inst/extdata/test_manifest.txt
@@ -1,0 +1,4 @@
+path	parent	specimenID	individualID	assay	fakeAnnotation	tissue	organ	metadataType	isMultiSpecimen	grant	consortium
+/foo/bar	syn20400157	a1	P01	rnaSeq	1	kleenex	wrong organ				
+/foo/baz	syn20400157	a2	P02	rnaSeq	2	puffs	another wrong organ				
+test_individual.csv	syn20400157							individual	TRUE		

--- a/vignettes/customizing-dccvalidator.Rmd
+++ b/vignettes/customizing-dccvalidator.Rmd
@@ -19,7 +19,10 @@ built-in Shiny application is designed to ensure that data conforms to a
 specific project organization structure in which data is organized into studies
 that are described with a combination of metadata files. These metadata files
 document the individuals, specimens, and assay(s) that were performed in the
-study.
+study. Documenting the data in this way allows researchers to describe the study
+at different levels while minimizing repetition. These metadata files can later
+be joined on the `individualID` and `specimenID` columns to create a table of
+all of the metadata for the study.
 
 For projects like AMP-AD, PsychENCODE, and others that follow the same
 structure, see the next section ("Customizing the Shiny application") for how
@@ -109,7 +112,8 @@ To install the dccvalidator instead of forking the repository:
   biospecimen template the app validates against.
 * `complete_columns`: For each metadata file and the manifest, a list of the
   columns that must be complete (i.e. not contain any missing values or empty
-  strings)
+  strings). For metadata files, this should typically include `"individualID"`
+  and/or `"specimenID"`.
 * `contact_email`: Email address linked in footer for users to contact if they
   have questions
 

--- a/vignettes/customizing-dccvalidator.Rmd
+++ b/vignettes/customizing-dccvalidator.Rmd
@@ -14,8 +14,24 @@ knitr::opts_chunk$set(
 )
 ```
 
-dccvalidator is intended to be customizable for different settings. The Shiny
-application uses a [configuration file](https://github.com/Sage-Bionetworks/dccvalidator/blob/master/config.yml)
+dccvalidator is intended customizable for different settings, however the
+built-in Shiny application is designed to ensure that data conforms to a
+specific project organization structure in which data is organized into studies
+that are described with a combination of metadata files. These metadata files
+document the individuals, specimens, and assay(s) that were performed in the
+study.
+
+For projects like AMP-AD, PsychENCODE, and others that follow the same
+structure, see the next section ("Customizing the Shiny application") for how
+configure an instance of the application for the project.
+
+For projects that do not follow the same structure but wish to use some elements
+of dccvalidator's data validation capabilities, see "Extending dccvalidator"
+below.
+
+## Customizing the Shiny application
+
+The Shiny app uses a [configuration file](https://github.com/Sage-Bionetworks/dccvalidator/blob/master/config.yml)
 to set details such as where to store uploaded files, which metadata templates
 to validate against, whom to contact with questions, etc.
 
@@ -63,7 +79,7 @@ To install the dccvalidator instead of forking the repository:
    See this
    [example of how to create a project with appropriate permissions](https://github.com/Sage-Bionetworks/dccvalidator/blob/master/inst/app/create_project.R).
    
-## Configuration options
+### Configuration options
 
 * `parent`: The Synapse project or folder where files will be stored
 * `path_to_markdown`: Location of an R Markdown document with app instructions. If you wish to omit instructions, insert `!expr NA`.
@@ -97,3 +113,168 @@ To install the dccvalidator instead of forking the repository:
 * `contact_email`: Email address linked in footer for users to contact if they
   have questions
 
+## Extending dccvalidator
+
+Users who wish to use dccvalidator for projects that do not follow the same
+structure as AMP-AD and PsychENCODE can do so by reusing the existing validation
+functions in their own R code, implementing new checks as needed, and reusing
+Shiny modules from dccvalidator.
+
+### Using validation functions in scripts
+
+Functions to check data for common quality issues are at the core of
+dccvalidator. These functions in dccvalidator are all named with the pattern
+`check_*()`: `check_annotation_keys()`, `check_annotation_values()`,
+`check_cols_empty()`, etc. 
+See the [function reference](https://sage-bionetworks.github.io/dccvalidator/reference/index.html#section-data-validation-functions) for a complete list.
+
+These functions are used in the dccvalidator Shiny app, but they can also be
+used in scripts or reports. Each function takes data as input and returns
+results in the form of custom condition objects. The condition objects inherit
+from R's `"message"`, `"warning"`, and `"error"` classes. However, rather than
+raising a message/warning/error, the check functions in dccvalidator return the
+condition objects themselves.
+
+```{r demo-check-function, message = FALSE}
+library("dccvalidator")
+library("readr")
+
+## Load a sample manifest
+manifest <- read_tsv(
+  system.file("extdata", "test_manifest.txt", package = "dccvalidator")
+)
+
+manifest
+
+## Check that required columns are complete in the manifest
+result <- check_cols_complete(
+  manifest,
+  required_cols = c("path", "parent", "grant")
+)
+
+result
+```
+
+The condition objects contain several useful pieces of information. There is a
+message describing the result of the check, as well as a message describing the
+expected outcome. For warnings and errors, the data that caused the warning or
+error is included.
+
+```{r see-result-details}
+result$message
+result$behavior
+result$data
+```
+
+### Creating new validation functions
+
+While we have functions for many data validation tasks, users may wish to create
+their own custom checking functions. The functions `check_pass()`,
+`check_warn()`, and `check_fail()` will create condition objects from the
+provided arguments. Here is an example of how one could write a custom function
+that checks if pH values are within an appropriate range.
+
+```{r custom-function}
+dat <- data.frame(pH = c(2, 6, 3, -2, 0, 15))
+
+check_values_ph <- function(data, ph_col = "pH",
+                            success_msg = "All pH values are valid",
+                            fail_msg = "Some pH values are outside the range 0-14",
+                            behavior_msg = "pH values should be between 0-14") {
+  values <- data[, ph_col, drop = TRUE]
+  if (all(values >= 0 & values <= 14)) {
+    check_pass(
+      msg = success_msg,
+      behavior = behavior_msg
+    )
+  } else {
+    check_fail(
+      msg = fail_msg,
+      behavior = behavior_msg,
+      data = values[values > 14 | values < 0]
+    )
+  }
+}
+
+check_values_ph(dat)
+```
+
+The `check_condition()` function can make the above a little more concise:
+
+```{r check-condition-example}
+check_values_ph <- function(data, ph_col = "pH",
+                            success_msg = "All pH values are valid",
+                            fail_msg = "Some pH values are outside the range 0-14",
+                            behavior_msg = "pH values should be between 0-14") {
+  values <- na.omit(data[, ph_col, drop = TRUE])
+  all_valid <- all(values >= 0 & values <= 14)
+  
+  check_condition(
+    msg = ifelse(all_valid, success_msg, fail_msg),
+    behavior = behavior_msg,
+    data = if (!all_valid) values[values > 14 | values < 0],
+    type = ifelse(all_valid, "check_pass", "check_fail")
+  )
+}
+```
+
+### Reusing app modules
+
+The Shiny app that dccvalidator provides allows users to see the results of data
+validation. This module (`results_boxes_server()`/`results_boxes_ui()`) is
+exported from dccvalidator and can be reused in other Shiny applications like so:
+
+```{r show-module-demo, eval = FALSE}
+library("shiny")
+library("shinydashboard")
+
+server <- function(input, output) {
+  # Load sample data
+  manifest <- read_tsv(
+    system.file("extdata", "test_manifest.txt", package = "dccvalidator")
+  )
+  biosp <- read_csv(
+    system.file("extdata", "test_biospecimen.csv", package = "dccvalidator")
+  )
+  
+  # Add logic to run the checks you are interested in and store the results in a
+  # list. Here is an example:
+  res <- list(
+    check_cols_complete(
+      manifest,
+      c("path", "parent", "grant"),
+      success_msg = "All required columns present are complete in the manifest",
+      fail_msg = "Some required columns are incomplete in the manifest"
+    ),
+    check_cols_complete(
+      biosp,
+      "specimenID",
+      success_msg = "All required columns present are complete in the biospecimen metadata",
+      fail_msg = "Some required columns are incomplete in the biospecimen metadata"
+    ),
+    check_specimen_ids_dup(
+      biosp,
+      success_msg = "Specimen IDs in the biospecimen metadata file are unique",
+      fail_msg = "Duplicate specimen IDs found in the biospecimen metadata file"
+    )
+  )
+  
+  # Show results in boxes
+  callModule(results_boxes_server, "Validation Results", res)
+}
+
+ui <- function(request) {
+  dashboardPage(
+    header = dashboardHeader(),
+    sidebar = dashboardSidebar(),
+    body = dashboardBody(
+      includeCSS(
+        system.file("app/www/custom.css", package = "dccvalidator")
+      ),
+      results_boxes_ui("Validation Results")
+    )
+  )
+}
+
+shinyApp(ui, server)
+```


### PR DESCRIPTION
Fixes #307 

Adds a lot of content to the "Customizing dccvalidator" vignette about how to reuse components of dccvalidator even if the exact structure of your project is different from what we enforce in AMP-AD/PEC. We now cover how to reuse dccvalidator's functions in scripts, how to create your own functions, and how to use the `results_boxes` module in other Shiny apps. In working on this, I noticed a place where the pkgdown documentation could be better organized to show exactly which functions are used for checking data, so I made that change as well.

For demonstration purposes I've included my 4 test files in `inst/extdata` (see also #311). I use some of these in the examples in the vignette, but we could still also host them on Synapse if we want an easier location for non R users to find them.