### PR TITLE
active sub-folder

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -75,7 +75,7 @@ amp-ad:
       - "specimenID"
 
 pec:
-  parent: "syn20825282"
+  parent: "syn21763123"
   path_to_markdown: "inst/using-the-dccvalidator-pec.Rmd"
   study_table: "syn20968992"
   annotations_table: "syn20981788"


### PR DESCRIPTION
This change is to enforce a folder structure in parent project with active, archived and dccmonitor.