### PR TITLE
Add config for annotations user research

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -131,3 +131,38 @@ pec:
       - "libraryPreparationMethod"
       - "runType"
   contact_email: "kelsey@synapse.org"
+
+annotations-research:
+  parent: "syn21782020"
+  annotations_table:
+    - "syn10242922"
+    - "syn21459391"
+  annotations_link: "https://shinypro.synapse.org/users/kwoo/amp-ad-metadata-dictionary/"
+  teams:
+    - "3407020"
+    - "273957"
+  study_link_ref: "https://adknowledgeportal.synapse.org/#/DataAccess/AcknowledgementStatements"
+  templates:
+    assay_templates:
+      proteomics: "syn12973255"
+      single cell RNAseq: "syn21018360"
+      wholeGenomeSeq: "syn21018358"
+      wholeExomeSeq: "syn21078272"
+      NanoString: "syn21082744"
+      snpArray: "syn21372586"
+      TMT quantitation: "syn21433357"
+  complete_columns:
+    manifest:
+      - "consortium"
+      - "study"
+      - "grant"
+      - "fileFormat"
+      - "parent"
+      - "path"
+    individual:
+      - "individualID"
+    biospecimen:
+      - "individualID"
+      - "specimenID"
+    assay:
+      - "specimenID"


### PR DESCRIPTION
Adds a config that is identical to AMP-AD except saves to a different project and allows anyone on either the "Sage Bionetworks" or "Annotations Design Research Participants" teams to upload.