### PR TITLE
Remove AMP-AD team from default settings

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -9,7 +9,6 @@ default:
   study_link_human: "https://adknowledgeportal.synapse.org/#/Explore/Studies?Study=syn3159438"
   study_link_ref: ""
   teams:
-    - "3320424"
     - "273957"
   templates:
     manifest_template: "syn20820080"


### PR DESCRIPTION
Fixes # NA

AMP-AD doesn't have permissions to create folders in the validation-sandbox project, which causes the app to crash if they log in while the config is set to default. Ultimately, it would be better to have a default view that shows it's not the AMP-AD version. This is a quick solution, but will not result in much less confusion since it will still tell the user that they need to be a part of the AMP-AD team.

@kelshmo What do you think? Should we push this change and make a separate issue to update the default config items (including a default vignette) when we get a chance? Or should we prioritize getting the default items done on this branch and push this change as a whole?

Changes proposed in this pull request:

- Remove AMP-AD team from the default teams in config.

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: NA
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: NA
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: NA
