### PR TITLE
Add modal if sessionToken is invalid

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -32,7 +32,17 @@ app_server <- function(input, output, session) {
   })
 
   observeEvent(input$cookie, {
-    syn$login(sessionToken = input$cookie)
+    tryCatch({
+      syn$login(sessionToken = input$cookie)
+    }, error = function(err) {
+      showModal(
+        modalDialog(
+          title = "Login error",
+          HTML("There was an error with the login process. Please refresh your Synapse session by logging out of and back in to <a target=\"_blank\" href=\"https://www.synapse.org/\">Synapse</a>. Then refresh this page to use the application."), # nolint
+          footer = NULL
+        )
+      )
+    })
 
     ## Check if user is in AMP-AD Consortium team (needed in order to create
     ## folder at the next step), and if they are a certified user.

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -32,8 +32,10 @@ app_server <- function(input, output, session) {
   })
 
   observeEvent(input$cookie, {
+    is_logged_in <- FALSE
     tryCatch({
       syn$login(sessionToken = input$cookie)
+      is_logged_in <- TRUE
     }, error = function(err) {
       showModal(
         modalDialog(
@@ -43,6 +45,7 @@ app_server <- function(input, output, session) {
         )
       )
     })
+    req(is_logged_in)
 
     ## Check if user is in AMP-AD Consortium team (needed in order to create
     ## folder at the next step), and if they are a certified user.


### PR DESCRIPTION
Fixes #290 (probably)

Changes proposed in this pull request:

- Add a modal that pops up if the app gets an error when trying to log in with the sessionToken cookie. I have tested it locally to see if the token itself is incorrect (do login with code changed to `syn$login(sessionToken = "some_string")`, then it will pop up the message. I don't know if the bad token error happens before this log in, but if it does, this would not solve the issue.

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: N/A
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: N/A
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: N/A
