### PR TITLE
Hopefully fix pkgdown deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - Rscript -e 'remotes::install_cran("pkgdown")'
     deploy:
       provider: script
-      script: Rscript -e 'pkgdown::deploy_site_github(verbose = TRUE)'
+      script: Rscript -e 'pkgdown::deploy_site_github(ssh_id = Sys.getenv("TRAVIS_DEPLOY_KEY", ""), verbose = TRUE)'
       skip_cleanup: true
       on:
         repo: Sage-Bionetworks/dccvalidator


### PR DESCRIPTION
Fixes #327. A change to the travis package altered the name of the environment variable where the deploy key was stored. I _think_ this should fix it.