### PR TITLE
Use github version of pkgdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
     stage: deploy
     r: release
     before_cache:
-    - Rscript -e 'remotes::install_cran("pkgdown")'
+    - Rscript -e 'remotes::install_github("pkgdown")'
     deploy:
       provider: script
       script: Rscript -e 'pkgdown::deploy_site_github(ssh_id = Sys.getenv("TRAVIS_DEPLOY_KEY", ""), verbose = TRUE)'


### PR DESCRIPTION
Fixes #327, hopefully for real. There were some recent pkgdown updates that I think we may need in order for Travis deployment to work. This PR ensures we are using the development version of pkgdown.