### PR TITLE
Add amp-ad specific biospecimen templates

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -58,6 +58,11 @@ amp-ad:
       human: "syn12973254"
       other mouse or animal model: "syn12973253"
       MODEL-AD mouse model: "syn21084071"
+    biospecimen_templates:
+      human: "syn12973252"
+      other mouse or animal model: "syn12973252"
+      MODEL-AD mouse model: "syn12973252"
+      drosophila: "syn20673251"
     assay_templates:
       proteomics: "syn12973255"
       single cell RNAseq: "syn21018360"


### PR DESCRIPTION
Fixes #331 - this is a continuation since I forgot to add specific amp-ad biospecimen templates and was inheriting the defaults that did not work anymore.

Changes proposed in this pull request:

- Add amp-ad biospecimen templates to config.yml

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: N/A
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: N/A
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: N/A
