### PR TITLE
Try github action for pkgdown deploy

### DIFF
--- a/.github/pkgdown.yaml
+++ b/.github/pkgdown.yaml
@@ -1,0 +1,42 @@
+on:
+  push:
+    branches: master
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@master
+
+      - uses: r-lib/actions/setup-pandoc@master
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), "depends.Rds", version = 2)
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: macOS-r-3.6-${{ hashFiles('depends.Rds') }}
+          restore-keys: macOS-r-3.6-
+
+      - name: Install dependencies
+        run: |
+          install.packages("remotes")
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_dev("pkgdown")
+        shell: Rscript {0}
+
+      - name: Install package
+        run: R CMD INSTALL .
+
+      - name: Deploy package
+        run: pkgdown::deploy_to_branch(new_process = FALSE)
+        shell: Rscript {0}

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,6 @@ jobs:
   - r: release
   - r: 3.5
   - r: 3.4
-  - if: branch = master
-    stage: deploy
-    r: release
-    before_cache:
-    - Rscript -e 'remotes::install_github("pkgdown")'
-    deploy:
-      provider: script
-      script: Rscript -e 'pkgdown::deploy_site_github(ssh_id = Sys.getenv("TRAVIS_DEPLOY_KEY", ""), verbose = TRUE)'
-      on:
-        repo: Sage-Bionetworks/dccvalidator
-        branch: master
   - if: type = pull_request
     stage: lint
     r: release


### PR DESCRIPTION
Fixes #327 (hopefully?)

Changes proposed in this pull request:

- Remove pkgdown deploy from .travis.yml
- Add github action to deploy pkgdown site

What do you think about trying this, @karawoo? The GitHub action was from [here](https://github.com/r-lib/actions/blob/master/examples/pkgdown.yaml). I didn't change anything since it appears to be reasonable.