### PR TITLE
Remove duplicated statement about CoC

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -58,16 +58,8 @@ you can run `git commit --no-verify` to skip all checks. Or, you can skip
 certain hooks by their ID (as shown in the file `.pre-commit-config.yaml`), e.g.
 `SKIP=roxygenize git commit -m "foo"`.
 
----
+### Code of Conduct
 
 Please note that the dccvalidator project is released with a [Contributor Code of Conduct](https://sage-bionetworks.github.io/dccvalidator/CODE_OF_CONDUCT).
 By contributing to this project, you agree to abide by its terms.
-
-
-### Code of Conduct
-
-Please note that the dccvalidator project is released with a
-[Contributor Code of Conduct](CODE_OF_CONDUCT.md). By contributing to this
-project you agree to abide by its terms.
-
 


### PR DESCRIPTION
The contributing guide had the code of conduct mentioned twice