### PR TITLE
Fix check_ages_over_90() when all ages in column are NA

### DIFF
--- a/R/check-ages-over-90.R
+++ b/R/check-ages-over-90.R
@@ -36,7 +36,7 @@ check_ages_over_90 <- function(data, col = "ageDeath", strict = FALSE,
   cols_in_data <- intersect(col, names(data))
   age_data <- data[, cols_in_data, drop = FALSE]
 
-  if (!any(purrr::map_lgl(age_data, ~ any(is_over_90(.x))))) {
+  if (!any(purrr::map_lgl(age_data, ~ isTRUE(any(is_over_90(.x)))))) {
     check_pass(
       msg = success_msg,
       behavior = behavior

--- a/tests/testthat/test-check-ages-over-90.R
+++ b/tests/testthat/test-check-ages-over-90.R
@@ -56,3 +56,12 @@ test_that("check_ages_over_90 can handle tibbles", {
   expect_true(inherits(res1, "check_warn"))
   expect_true(inherits(res2, "check_warn"))
 })
+
+test_that("check_ages_over_90 doesn't fail if all NA", {
+  dat1 <- data.frame(ageDeath = NA)
+  dat2 <- data.frame(age1 = c(NA, NA), age2 = c(NA, NA))
+  res1 <- check_ages_over_90(dat1)
+  res2 <- check_ages_over_90(dat2, col = c("age1", "age2"))
+  expect_true(inherits(res1, "check_pass"))
+  expect_true(inherits(res2, "check_pass"))
+})


### PR DESCRIPTION
Fixes #352 

Changes proposed in this pull request:

- If all values in the age column are NA, `check_ages_over_90()` will return `"check_pass"`.

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: yes
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: NA
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: NA
