### PR TITLE
Don't return NAs in final data

### DIFF
--- a/R/check-ages-over-90.R
+++ b/R/check-ages-over-90.R
@@ -36,7 +36,7 @@ check_ages_over_90 <- function(data, col = "ageDeath", strict = FALSE,
   cols_in_data <- intersect(col, names(data))
   age_data <- data[, cols_in_data, drop = FALSE]
 
-  if (!any(purrr::map_lgl(age_data, ~ isTRUE(any(is_over_90(.x)))))) {
+  if (!any(purrr::map_lgl(age_data, ~ any(is_over_90(.x))))) {
     check_pass(
       msg = success_msg,
       behavior = behavior
@@ -55,8 +55,8 @@ check_ages_over_90 <- function(data, col = "ageDeath", strict = FALSE,
 }
 
 # Does the column (after removing non-numeric characters) contain any values
-# >90?
+# >90? NAs are not considered over 90 and will evaluate to FALSE.
 is_over_90 <- function(x) {
   col_numeric <- gsub("[^0-9]", "", x)
-  as.numeric(as.character(col_numeric)) > 90
+  (as.numeric(as.character(col_numeric)) > 90) %in% TRUE
 }

--- a/tests/testthat/test-check-ages-over-90.R
+++ b/tests/testthat/test-check-ages-over-90.R
@@ -65,3 +65,14 @@ test_that("check_ages_over_90 doesn't fail if all NA", {
   expect_true(inherits(res1, "check_pass"))
   expect_true(inherits(res2, "check_pass"))
 })
+
+test_that("check_ages_over_90 doesn't return NAs in data", {
+  dat <- data.frame(ageDeath = c(NA, 95))
+  res <- check_ages_over_90(dat)
+  expect_equal(res$data, list(ageDeath = 95))
+})
+
+test_that("is_over_90 considers NAs not greater than 90", {
+  x <- c(NA, 95, NA, 90)
+  expect_equal(is_over_90(x), c(FALSE, TRUE, FALSE, FALSE))
+})


### PR DESCRIPTION
#353 fixed the bug in #352 but returned NAs in the final data.

``` r
dat <- data.frame(ageDeath = c(NA, 95))
res <- check_ages_over_90(dat)
res$data
#> $ageDeath
#> [1] NA 95
```

<sup>Created on 2020-04-28 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

This fixes that by updating `is_over_90()` so it considers `NA` not greater than 90 rather than returning NAs.