### PR TITLE
Leave decimals alone when checking ages

### DIFF
--- a/R/check-ages-over-90.R
+++ b/R/check-ages-over-90.R
@@ -57,6 +57,12 @@ check_ages_over_90 <- function(data, col = "ageDeath", strict = FALSE,
 # Does the column (after removing non-numeric characters) contain any values
 # >90? NAs are not considered over 90 and will evaluate to FALSE.
 is_over_90 <- function(x) {
-  col_numeric <- gsub("[^0-9]", "", x)
-  (as.numeric(as.character(col_numeric)) > 90) %in% TRUE
+  if (inherits(x, "character") || inherits(x, "factor")) {
+    col_numeric <- as.numeric(gsub("[^0-9|\\.]", "", x))
+  } else if (inherits(x, "numeric") || inherits(x, "integer")) {
+    col_numeric <- x
+  } else {
+    col_numeric <- as.numeric(x)
+  }
+  (col_numeric > 90) %in% TRUE
 }

--- a/tests/testthat/test-check-ages-over-90.R
+++ b/tests/testthat/test-check-ages-over-90.R
@@ -76,3 +76,17 @@ test_that("is_over_90 considers NAs not greater than 90", {
   x <- c(NA, 95, NA, 90)
   expect_equal(is_over_90(x), c(FALSE, TRUE, FALSE, FALSE))
 })
+
+test_that("is_over_90() preserves decimal ages in characters and factor", {
+  x <- c(89.9, 90.9)
+  y <- c("89.9", "90+", "95.5")
+  z <- factor(c("99.9", "90+"))
+  expect_equal(is_over_90(x), c(FALSE, TRUE))
+  expect_equal(is_over_90(y), c(FALSE, FALSE, TRUE))
+  expect_equal(is_over_90(z), c(TRUE, FALSE))
+})
+
+test_that("is_over_90 coerces non-character or numeric values to numeric", {
+  expect_false(is_over_90(TRUE))
+  expect_false(is_over_90(FALSE))
+})


### PR DESCRIPTION
Fixes #355 

Changes proposed in this pull request:

Allows `is_over_90()` to accept decimal values 😳 . I've done this in two ways to be extra safe: if the column is numeric, then we don't fuss with special characters at all. If it's character or factor, we still leave decimal points intact. 

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions yes
- If adding a new exported function, added it to the reference section of `_pkgdown.yml` NA
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd` NA
