### PR TITLE
Add ATACseq to amp-ad config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -64,7 +64,7 @@ amp-ad:
       MODEL-AD mouse model: "syn12973252"
       drosophila: "syn20673251"
     assay_templates:
-      ATACseq: "syn22024364.1"
+      ATACseq: "syn22024364"
       proteomics: "syn12973255"
       single cell RNAseq: "syn21018360"
       wholeGenomeSeq: "syn21018358"

--- a/config.yml
+++ b/config.yml
@@ -64,6 +64,7 @@ amp-ad:
       MODEL-AD mouse model: "syn12973252"
       drosophila: "syn20673251"
     assay_templates:
+      ATACseq: "syn22024364.1"
       proteomics: "syn12973255"
       single cell RNAseq: "syn21018360"
       wholeGenomeSeq: "syn21018358"


### PR DESCRIPTION
Fixes # N/A; config needed to be updated for new config.

Changes proposed in this pull request:

- Add ATACseq assay template to config.

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: N/A
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: N/A
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: N/A
