### PR TITLE
Add methylationArray assay to amp-ad config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -72,6 +72,7 @@ amp-ad:
       NanoString: "syn21082744"
       snpArray: "syn21372586"
       TMT quantitation: "syn21433357"
+      methylationArray: "syn22036881"
   complete_columns:
     manifest:
       - "consortium"


### PR DESCRIPTION
Fixes # n/a. Config update.

Changes proposed in this pull request:

- add methylationArray assay to amp-ad config

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: n/a
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: n/a
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: n/a
