### PR TITLE
Add ad templates for mri, pet, and autorad

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -65,6 +65,7 @@ amp-ad:
       drosophila: "syn20673251"
     assay_templates:
       ATACseq: "syn22024364"
+      autorad: "syn22087295"
       proteomics: "syn12973255"
       single cell RNAseq: "syn21018360"
       wholeGenomeSeq: "syn21018358"
@@ -73,6 +74,8 @@ amp-ad:
       snpArray: "syn21372586"
       TMT quantitation: "syn21433357"
       methylationArray: "syn22036881"
+      mri: "syn22087332"
+      pet: "syn22087299"
   complete_columns:
     manifest:
       - "consortium"


### PR DESCRIPTION
Fixes # N/A.

Changes proposed in this pull request:

- Added templates to AD config for imaging and autorad.

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: n/a
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: n/a
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: n/a
