### PR TITLE
Change imaging template names to uppercase

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -74,8 +74,8 @@ amp-ad:
       snpArray: "syn21372586"
       TMT quantitation: "syn21433357"
       methylationArray: "syn22036881"
-      mri: "syn22087332"
-      pet: "syn22087299"
+      MRI: "syn22087332"
+      PET: "syn22087299"
   complete_columns:
     manifest:
       - "consortium"


### PR DESCRIPTION
I'm just being finicky... Didn't realize it would annoy me to have them lowercase until I saw it in the validator.

Fixes # N/A

Changes proposed in this pull request:

- Change the names mri and pet to MRI and PET.

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: N/A
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: N/A
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: N/A
