### PR TITLE
Add immunoassay to ad config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -66,6 +66,7 @@ amp-ad:
     assay_templates:
       ATACseq: "syn22024364"
       autorad: "syn22087295"
+      immunoassay: "syn22117582"
       proteomics: "syn12973255"
       single cell RNAseq: "syn21018360"
       wholeGenomeSeq: "syn21018358"


### PR DESCRIPTION
Fixes # N/A

Changes proposed in this pull request:

- Add immunoassay template to AD config

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: N/A
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: N/A
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: N/A
