### PR TITLE
Make anything coercible to character

### DIFF
--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -335,11 +335,8 @@ can_coerce <- function(values, class) {
     return(TRUE)
   }
 
-  if (class == "character" &&
-    (inherits(values, "numeric") | inherits(values, "integer") |
-      inherits(values, "logical") | inherits(values, "factor"))) {
-    ## Anything is coercible to character
-    return(TRUE)
+  if (class == "character") {
+    return(TRUE) # Anything is coercible to character
   } else if (class == "numeric" && inherits(values, "integer")) {
     ## Integers are coercible to numeric
     return(TRUE)

--- a/tests/testthat/test-check-annotation-values.R
+++ b/tests/testthat/test-check-annotation-values.R
@@ -415,10 +415,14 @@ test_that("Multiple column types produces an error", {
 
 ## can_coerce() ----------------------------------------------------------------
 
-test_that("can_coerce() returns TRUE for numeric/integer/boolean->character", {
+test_that("anything is coercible to character", {
   expect_true(can_coerce(1, "character"))
   expect_true(can_coerce(1L, "character"))
   expect_true(can_coerce(TRUE, "character"))
+  expect_true(can_coerce(as.Date("2020-05-01"), "character"))
+  expect_true(can_coerce(as.POSIXct("2020-05-01"), "character"))
+  expect_true(can_coerce(as.POSIXlt("2020-05-01"), "character"))
+  expect_true(can_coerce(as.complex(-1), "character"))
 })
 
 test_that("can_coerce() returns TRUE for integer->numeric", {
@@ -462,7 +466,6 @@ test_that("a value can be coerced to its own type", {
 
 test_that("factors are converted to string before checking coercibility", {
   expect_true(can_coerce(factor("TRUE"), "logical"))
-  expect_true(can_coerce(factor("foo"), "character"))
 })
 
 test_that("whole numbers that aren't integer type are considered coercible", {


### PR DESCRIPTION
Fixes #383

Changes proposed in this pull request:

- Ensures that any class is treated as coercible to character. Rather than explicitly naming date classes, we now treat _any_ class as coercible to character. I don't see a reason not to do this, but @Aryllen let me know if you think there's something I'm missing.

Please confirm you've done the following (if applicable):

- Added tests for new functions or for new behavior in existing functions: yes
- If adding a new exported function, added it to the reference section of `_pkgdown.yml`: N/A
- If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`: N/A
