### PR TITLE
Update for development version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0
+Version: 0.3.0.9000
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# dccvalidator (development version)
+
 # dccvalidator v0.3.0
 
 - Add `check_parent_syn()`


### PR DESCRIPTION
v0.3.0 is released on CRAN and the version tagged in GH. This PR updates the master branch to be ready for new changes.

Changes proposed in this pull request:

- Add 9000 back to the version number to signify it is the development version
- Update NEWS.md to have top section for tracking changes to dccvalidator since the last release
