### PR TITLE
add ref to PEC master table

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -98,6 +98,7 @@ pec:
   parent: "syn21763123"
   path_to_markdown: "inst/using-the-dccvalidator-pec.Rmd"
   study_table: "syn20968992"
+  samples_table: "syn22175287"
   annotations_table: "syn20981788"
   annotations_link: "https://www.synapse.org/#!Synapse:syn20729790"
   templates_link: "https://www.synapse.org/#!Synapse:syn20729790"

--- a/vignettes/customizing-dccvalidator.Rmd
+++ b/vignettes/customizing-dccvalidator.Rmd
@@ -87,7 +87,10 @@ To install the dccvalidator instead of forking the repository:
 * `parent`: The Synapse project or folder where files will be stored
 * `path_to_markdown`: Location of an R Markdown document with app instructions. If you wish to omit instructions, insert `!expr NA`.
 * `study_table`: Synapse ID of a table that lists all of the existing studies in
-  the consortium. It should have a column called `StudyName`.
+  the consortium. It should have a column called `StudyName`
+* `samples_table`: Synapse ID of a table that lists the key-value pairs of `study`, `individualID`,
+  `specimenID`, `assay`, `species` to validate that additions to existing studies retain all IDs
+  that were previously shared.
 * `annotations_table`: Synapse ID of a table that lists allowable annotation
   keys and values for the consortium. This should follow the same basic format
   as our Synapse Annotations table, e.g. there must be the following columns:


### PR DESCRIPTION
Changes proposed in this pull request:

- Add reference to PEC Master table

Please confirm you've done the following (if applicable):

- [x] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md` - _looks like NEWS is only in the master branch_
