### PR TITLE
Update README badge

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 
 # dccvalidator
 
-[![Travis-CI Build Status](https://travis-ci.org/Sage-Bionetworks/dccvalidator.svg?branch=master)](https://travis-ci.org/Sage-Bionetworks/dccvalidator)
+![R-CMD-check](https://github.com/Sage-Bionetworks/dccvalidator/workflows/R-CMD-check/badge.svg?branch=master)
 [![CRAN status](https://www.r-pkg.org/badges/version/dccvalidator)](https://CRAN.R-project.org/package=dccvalidator)
 [![lifecycle](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 # dccvalidator
 
-[![Travis-CI Build
-Status](https://travis-ci.org/Sage-Bionetworks/dccvalidator.svg?branch=master)](https://travis-ci.org/Sage-Bionetworks/dccvalidator)
+![R-CMD-check](https://github.com/Sage-Bionetworks/dccvalidator/workflows/R-CMD-check/badge.svg?branch=master)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/dccvalidator)](https://CRAN.R-project.org/package=dccvalidator)
 [![lifecycle](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)


### PR DESCRIPTION
#396 switched us to using github actions but forgot to update the badge on the README

Changes proposed in this pull request:

- removes Travis-CI badge and adds GitHub Actions badge

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
