### PR TITLE
Fix infobox bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9001
+Version: 0.3.0.9002
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # dccvalidator (development version)
 
 - Add `check_complete_ids()` and `samples_table` configuration option
+- Fix bug in Data Summary information boxes to not count NA
 
 # dccvalidator v0.3.0
 

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -301,13 +301,11 @@ app_server <- function(input, output, session) {
     ## Counts of individuals, specimens, and files
     output$nindividuals <- renderValueBox({
       valueBox(
-        sum(!is.na(unique(
-          c(
-            indiv()$individualID,
-            biosp()$individualID,
-            manifest()$individualID
-          )
-        ))),
+        count_unique_values(
+          indiv()$individualID,
+          biosp()$individualID,
+          manifest()$individiualID
+        ),
         "Individuals",
         icon = icon("users")
       )
@@ -315,9 +313,11 @@ app_server <- function(input, output, session) {
 
     output$nspecimens <- renderValueBox({
       valueBox(
-        sum(!is.na(unique(
-          c(biosp()$specimenID, assay()$specimenID, manifest()$specimenID)
-        ))),
+        count_unique_values(
+          biosp()$specimenID,
+          assay()$specimenID,
+          manifest()$specimenID
+        ),
         "Specimens",
         icon = icon("vial")
       )
@@ -325,9 +325,7 @@ app_server <- function(input, output, session) {
 
     output$ndatafiles <- renderValueBox({
       valueBox(
-        sum(!is.na(unique(
-          manifest()$path
-        ))),
+        count_unique_values(manifest()$path),
         "Data files in manifest",
         icon = icon("file")
       )

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -301,15 +301,13 @@ app_server <- function(input, output, session) {
     ## Counts of individuals, specimens, and files
     output$nindividuals <- renderValueBox({
       valueBox(
-        length(
-          unique(
-            c(
-              indiv()$individualID,
-              biosp()$individualID,
-              manifest()$individualID
-            )
+        sum(!is.na(unique(
+          c(
+            indiv()$individualID,
+            biosp()$individualID,
+            manifest()$individualID
           )
-        ),
+        ))),
         "Individuals",
         icon = icon("users")
       )
@@ -317,11 +315,9 @@ app_server <- function(input, output, session) {
 
     output$nspecimens <- renderValueBox({
       valueBox(
-        length(
-          unique(
-            c(biosp()$specimenID, assay()$specimenID, manifest()$specimenID)
-          )
-        ),
+        sum(!is.na(unique(
+          c(biosp()$specimenID, assay()$specimenID, manifest()$specimenID)
+        ))),
         "Specimens",
         icon = icon("vial")
       )
@@ -329,11 +325,9 @@ app_server <- function(input, output, session) {
 
     output$ndatafiles <- renderValueBox({
       valueBox(
-        length(
-          unique(
-            manifest()$path
-          )
-        ),
+        sum(!is.na(unique(
+          manifest()$path
+        ))),
         "Data files in manifest",
         icon = icon("file")
       )
@@ -367,6 +361,5 @@ app_server <- function(input, output, session) {
         vals
       )
     })
-
   })
 }

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -304,7 +304,7 @@ app_server <- function(input, output, session) {
         count_unique_values(
           indiv()$individualID,
           biosp()$individualID,
-          manifest()$individiualID
+          manifest()$individualID
         ),
         "Individuals",
         icon = icon("users")

--- a/R/utils.R
+++ b/R/utils.R
@@ -68,3 +68,8 @@ save_to_synapse <- function(input_file,
 "%||%" <- function(a, b) {
   if (!is.null(a)) a else b
 }
+
+## Count unique values
+count_unique_values <- function(...) {
+  sum(!is.na(unique(c(...))))
+}

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -41,3 +41,13 @@ test_that("%||% gives b if a is NULL", {
   b <- NULL
   expect_null(a %||% b)
 })
+
+test_that("count_unique_values returns correct number", {
+  expect_equal(count_unique_values(1, 2, 3), 3)
+  expect_equal(count_unique_values(1, 1, 1), 1)
+  expect_equal(count_unique_values("a"), 1)
+  # Should not count NA as a unique value
+  expect_equal(count_unique_values(NA), 0)
+  expect_equal(count_unique_values("a", NA, NA), 1)
+  expect_equal(count_unique_values(c(NA), c(1, 2), c("a", "b")), 4)
+})


### PR DESCRIPTION
Fixes #368

Changes proposed in this pull request:

- Count individualID and specimenID differently. Instead of getting the number of strings returned from `unique()`, get a vector of `TRUE`/`FALSE` by asking if those strings are `!is.na()` and sum.

Please confirm you've done the following (if applicable):

- [x] Added tests for new functions or for new behavior in existing functions
- [ ] ~If adding a new exported function, added it to the reference section of `_pkgdown.yml`~
- [ ] ~If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`~
- [x] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
