### PR TITLE
Add check for ages over 90 in samplingAge column of biospecimen file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9002
+Version: 0.3.0.9003
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Add `check_complete_ids()` and `samples_table` configuration option
 - Fix bug in Data Summary information boxes to not count NA
+- `check_all()` now checks the biospecimen metadata for ages over 90 in the
+  `samplingAge` column
 
 # dccvalidator v0.3.0
 

--- a/R/check-all.R
+++ b/R/check-all.R
@@ -243,9 +243,19 @@ check_all <- function(data, annotations, study, syn) {
 
   # Ages over 90 are censored in human individual metadata ---------------------
   if (any(data$species == "human", na.rm = TRUE)) {
-    ages_over_90 <- check_ages_over_90(data$file_data[indiv_index][[1]])
+    ages_over_90_indiv <- check_ages_over_90(
+      data$file_data[indiv_index][[1]],
+      success_msg = "No ages over 90 detected in the individual metadata",
+      fail_msg = "Ages over 90 detected in the individual metadata"
+    )
+    ages_over_90_biosp <- check_ages_over_90(
+      data$file_data[biosp_index][[1]],
+      col = "samplingAge",
+      success_msg = "No ages over 90 detected in the biospecimen metadata",
+      fail_msg = "Ages over 90 detected in the biospecimen metadata"
+    )
   } else {
-    ages_over_90 <- NULL
+    ages_over_90_biosp <- ages_over_90_indiv <- NULL
   }
 
   # No file paths are duplicated in the manifest -------------------------------
@@ -317,7 +327,8 @@ check_all <- function(data, annotations, study, syn) {
     complete_cols_assay = complete_cols_assay,
     meta_files_in_manifest = meta_files_in_manifest,
     valid_parent_syn = valid_parent_syn,
-    ages_over_90 = ages_over_90,
+    ages_over_90_indiv = ages_over_90_indiv,
+    ages_over_90_biosp = ages_over_90_biosp,
     duplicate_file_paths = duplicate_file_paths,
     complete_ids_indiv = complete_ids_indiv,
     complete_ids_biosp = complete_ids_biosp,

--- a/tests/testthat/test-check-all.R
+++ b/tests/testthat/test-check-all.R
@@ -284,9 +284,37 @@ test_that("check_all runs check_ages_over_90 for human data", {
     study = "foo",
     syn = syn
   )
-  expect_true(inherits(res1$ages_over_90, "check_warn"))
-  expect_null(res2$ages_over_90)
-  expect_true(inherits(res3$ages_over_90, "check_warn"))
+  expect_true(inherits(res1$ages_over_90_indiv, "check_warn"))
+  expect_null(res2$ages_over_90_indiv)
+  expect_true(inherits(res3$ages_over_90_indiv, "check_warn"))
+})
+
+test_that("check_all runs check_ages_over_90 on biospecimen file", {
+  skip_if_not(logged_in(syn = syn))
+  dat <- tibble::tibble(
+    metadataType = c(
+      "manifest",
+      "individual",
+      "biospecimen",
+      "assay"
+    ),
+    name = c("file1", "file2", "file3", "file4"),
+    species = "human",
+    assay = "rnaSeq",
+    file_data = c(
+      list(data.frame(a = 1)),
+      list(data.frame(a = 1)),
+      list(data.frame(samplingAge = 100)),
+      list(data.frame(a = 1))
+    )
+  )
+  res <- check_all(
+    data = dat,
+    annotations = annots,
+    study = "foo",
+    syn = syn
+  )
+  expect_true(inherits(res$ages_over_90_biosp, "check_warn"))
 })
 
 test_that("check_all catches duplicate file paths in manifest", {


### PR DESCRIPTION
Fixes #403

Changes proposed in this pull request:

- Adds a check to `check_all()` that checks the biospecimen file for ages > 90 in the `samplingAge` column. I have not changed the default `col` argument to `check_ages_over_90()` (I just override it when checking the biospecimen). @Aryllen let me know if that's ok with you or if you'd like the default argument changed as well.

Please confirm you've done the following (if applicable):

- [X] Added tests for new functions or for new behavior in existing functions
- [ ] ~If adding a new exported function, added it to the reference section of `_pkgdown.yml`~
- [ ] ~If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`~
- [ ] ~If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`~
