### PR TITLE
Collapse successes box by default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9003
+Version: 0.3.0.9004
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/R/mod-results-boxes.R
+++ b/R/mod-results-boxes.R
@@ -48,6 +48,7 @@ results_boxes_ui <- function(id) {
       uiOutput(ns("successes")),
       solidHeader = TRUE,
       collapsible = TRUE,
+      collapsed = TRUE,
       title = textOutput(ns("num_success")),
       status = "success",
       width = 12


### PR DESCRIPTION
Fixes #374

@karawoo, I tried reorganizing the boxes, but it feels like there is too much emphasis on failure. I may be reading too much into that, though. Below is an image of what it looks like with them reorganized and the successes box collapsed by default. What do you think: should collapsing the successes box be enough or should we also reorg the boxes?

![image](https://user-images.githubusercontent.com/25048342/91747618-5d75f780-eb73-11ea-9508-09e0d4fdba5f.png)

Changes proposed in this pull request:

- Make successes box collapsed on startup

Please confirm you've done the following (if applicable):

~~- [ ] Added tests for new functions or for new behavior in existing functions~~
~~- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`~~
~~- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`~~
~~- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`~~
