### PR TITLE
Add info to the results boxes explaining how to interpret them

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9004
+Version: 0.3.0.9005
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Fix bug in Data Summary information boxes to not count NA
 - `check_all()` now checks the biospecimen metadata for ages over 90 in the
   `samplingAge` column
+- Results boxes now contain explanations of their contents
 
 # dccvalidator v0.3.0
 

--- a/R/app-ui.R
+++ b/R/app-ui.R
@@ -144,7 +144,7 @@ app_ui <- function(request) {
                     results_boxes_ui("Validation Results")
                   ),
                   tabPanel(
-                    "Data summary",
+                    "Data Summary",
                     fluidRow(
                       shinydashboard::box(
                         title = "Dataset summary",

--- a/R/mod-results-boxes.R
+++ b/R/mod-results-boxes.R
@@ -50,6 +50,7 @@ results_boxes_ui <- function(id) {
       collapsible = TRUE,
       collapsed = TRUE,
       title = textOutput(ns("num_success")),
+      footer = "Your files passed these checks. Well done!",
       status = "success",
       width = 12
     ),
@@ -58,6 +59,7 @@ results_boxes_ui <- function(id) {
       solidHeader = TRUE,
       collapsible = TRUE,
       title = textOutput(ns("num_warn")),
+      footer = "Warnings highlight possible issues in the data, but they may not be applicable to every dataset. If they are not applicable for your data, you can ignore them. For example, if any columns are completely empty they will generate a warning. If you did not collect data for that column, then you can ignore the warning.", # nolint
       status = "warning",
       width = 12
     ),
@@ -66,6 +68,7 @@ results_boxes_ui <- function(id) {
       solidHeader = TRUE,
       collapsible = TRUE,
       title = textOutput(ns("num_fail")),
+      footer = "Any failures in this box must be corrected. Contact the DCC team if you have any questions.", # nolint
       status = "danger",
       width = 12
     )

--- a/R/mod-results-boxes.R
+++ b/R/mod-results-boxes.R
@@ -68,7 +68,7 @@ results_boxes_ui <- function(id) {
       solidHeader = TRUE,
       collapsible = TRUE,
       title = textOutput(ns("num_fail")),
-      footer = "Any failures in this box must be corrected. Contact the DCC team if you have any questions.", # nolint
+      footer = "Any failures in this box must be corrected. A summary of data uploaded can be found in the Data Summary tab, and may help discover the reason behind the failures. Contact the DCC team if you have any questions.", # nolint
       status = "danger",
       width = 12
     )


### PR DESCRIPTION
Fixes #375

Changes proposed in this pull request:

Each results box now has a footer that explains how to interpret the box. These appear on startup (before results are populated) and persist once the check results have been generated. One thing that might be weird is that the success box message says "Your files passed these checks. Well done!" before there are any successes. Should I change the wording? The box is collapsed by default, so maybe it doesn't really matter.

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions: we don't have any functions for this module yet and I didn't add them, but let me know if you want them
~- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`~
~- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`~
- [X] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`