### PR TITLE
Hover tips

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9005
+Version: 0.3.0.9007
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9004
+Version: 0.3.0.9005
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9003
+Version: 0.3.0.9004
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9008
+Version: 0.3.0.9009
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Fix bug in Data Summary information boxes to not count NA
 - `check_all()` now checks the biospecimen metadata for ages over 90 in the
   `samplingAge` column
+- Results boxes now contain explanations of their contents
 
 # dccvalidator v0.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 - `check_all()` now checks the biospecimen metadata for ages over 90 in the
   `samplingAge` column
 - Results boxes now contain explanations of their contents
+- All tooltips now pop-up with hover instead of clicking
+- Add hover tooltips to all fileInputs
+- Fix bug in behavior for `check_ages_over_90()` and `check_parent_syn()`
 
 # dccvalidator v0.3.0
 

--- a/R/app-reporting.R
+++ b/R/app-reporting.R
@@ -34,7 +34,7 @@ report_result <- function(result, emoji_prefix = NULL, verbose = FALSE) {
         "Information",
         result$behavior,
         placement = "left",
-        trigger = "click"
+        trigger = "hover"
       )
     )
   } else {
@@ -50,7 +50,7 @@ report_result <- function(result, emoji_prefix = NULL, verbose = FALSE) {
         "Information",
         result$behavior,
         placement = "left",
-        trigger = "click"
+        trigger = "hover"
       )
     )
   }
@@ -118,7 +118,7 @@ show_details.list <- function(x) {
 #'   teams = "3396691",
 #'   user = user,
 #'   syn = syn
-#'  )
+#' )
 #' certified <- check_certified_user(user$ownerId, syn = syn)
 #' report_unsatisfied_requirements(membership, certified, syn = syn)
 #' }

--- a/R/app-ui.R
+++ b/R/app-ui.R
@@ -126,7 +126,7 @@ app_ui <- function(request) {
                     )
                   ),
                   "Information",
-                  "Select the assay metadata file. This file should have one row per specimen, with data about the assay performed on each specimen in the experiment. If adding a new dataset to an existing dataset, please include all previous assay specimens.", # nolint
+                  "Select the assay metadata file. Depending on the assay, this file should have one row per specimen or one row per individual (indicated in the template), with data about the assay performed on each specimen or individual in the experiment. If adding a new dataset to an existing dataset, please include all previous assay specimens or individuals. Please be sure to choose the correct assay type from the drop-down above, as well.", # nolint
                   placement = "top",
                   trigger = "hover"
                 ),

--- a/R/app-ui.R
+++ b/R/app-ui.R
@@ -71,10 +71,32 @@ app_ui <- function(request) {
                 # Files to be validated
                 conditionalPanel(
                   condition = "input.species != 'drosophila'",
+
+                  popify(
+                    shinyjs::disabled(
+                      fileInput(
+                        "indiv_meta",
+                        "Individual metadata file (.csv)",
+                        width = NULL,
+                        accept = c(
+                          "text/csv",
+                          "text/comma-separated-values,text/plain",
+                          ".csv"
+                        )
+                      )
+                    ),
+                    "Information",
+                    "Select the individual metadata file. This file should have one row per individual, with data about each individual in the experiment. If adding a new dataset to an existing dataset, please include all previous individuals.", # nolint
+                    placement = "top",
+                    trigger = "hover"
+                  )
+                ),
+
+                popify(
                   shinyjs::disabled(
                     fileInput(
-                      "indiv_meta",
-                      "Individual metadata file (.csv)",
+                      "biosp_meta",
+                      "Biospecimen metadata file (.csv)",
                       width = NULL,
                       accept = c(
                         "text/csv",
@@ -82,46 +104,50 @@ app_ui <- function(request) {
                         ".csv"
                       )
                     )
-                  )
+                  ),
+                  "Information",
+                  "Select the biospecimen metadata file. This file should have one row per specimen, with data about each specimen in the experiment. If adding a new dataset to an existing dataset, please include all previous specimens.", # nolint
+                  placement = "top",
+                  trigger = "hover"
                 ),
 
-                shinyjs::disabled(
-                  fileInput(
-                    "biosp_meta",
-                    "Biospecimen metadata file (.csv)",
-                    width = NULL,
-                    accept = c(
-                      "text/csv",
-                      "text/comma-separated-values,text/plain",
-                      ".csv"
+
+                popify(
+                  shinyjs::disabled(
+                    fileInput(
+                      "assay_meta",
+                      "Assay metadata file (.csv)",
+                      width = NULL,
+                      accept = c(
+                        "text/csv",
+                        "text/comma-separated-values,text/plain",
+                        ".csv"
+                      )
                     )
-                  )
+                  ),
+                  "Information",
+                  "Select the assay metadata file. This file should have one row per specimen, with data about the assay performed on each specimen in the experiment. If adding a new dataset to an existing dataset, please include all previous assay specimens.", # nolint
+                  placement = "top",
+                  trigger = "hover"
                 ),
 
-                shinyjs::disabled(
-                  fileInput(
-                    "assay_meta",
-                    "Assay metadata file (.csv)",
-                    width = NULL,
-                    accept = c(
-                      "text/csv",
-                      "text/comma-separated-values,text/plain",
-                      ".csv"
+                popify(
+                  shinyjs::disabled(
+                    fileInput(
+                      "manifest",
+                      "Upload Manifest File (.tsv or .txt)",
+                      multiple = FALSE,
+                      accept = c(
+                        "text/tsv",
+                        "text/tab-separated-values,text/plain",
+                        ".tsv"
+                      )
                     )
-                  )
-                ),
-
-                shinyjs::disabled(
-                  fileInput(
-                    "manifest",
-                    "Upload Manifest File (.tsv or .txt)",
-                    multiple = FALSE,
-                    accept = c(
-                      "text/tsv",
-                      "text/tab-separated-values,text/plain",
-                      ".tsv"
-                    )
-                  )
+                  ),
+                  "Information",
+                  "Select the manifest file. This file should have one row file to be uploaded to Synapse, including the metadata files, with data about the contents of each file, as well as the study itself. The manifest will be used to upload the data.", # nolint
+                  placement = "top",
+                  trigger = "hover"
                 ),
 
                 # Add an indicator feature to validate button

--- a/R/app-ui.R
+++ b/R/app-ui.R
@@ -52,19 +52,45 @@ app_ui <- function(request) {
                 # UI for getting the study name
                 get_study_ui("study"),
 
-                shinyjs::disabled(
-                  radioButtons(
-                    "species",
-                    "Species",
-                    config::get("species_list")
+                div(
+                  class = "result",
+                  div(
+                    class = "wide",
+                    shinyjs::disabled(
+                      radioButtons(
+                        "species",
+                        "Species",
+                        config::get("species_list")
+                      )
+                    )
+                  ),
+                  popify(
+                    tags$a(icon(name = "question-circle"), href = "#"),
+                    "Information",
+                    "Select the species used in the study.",
+                    placement = "left",
+                    trigger = "hover"
                   )
                 ),
 
-                shinyjs::disabled(
-                  selectInput(
-                    "assay_name",
-                    "Assay type",
-                    names(config::get("templates")$assay_templates)
+                div(
+                  class = "result",
+                  div(
+                    class = "wide",
+                    shinyjs::disabled(
+                      selectInput(
+                        "assay_name",
+                        "Assay type",
+                        names(config::get("templates")$assay_templates)
+                      )
+                    )
+                  ),
+                  popify(
+                    tags$a(icon(name = "question-circle"), href = "#"),
+                    "Information",
+                    "Select the type of assay that matches your assay metadata.", # nolint
+                    placement = "left",
+                    trigger = "hover"
                   )
                 ),
 

--- a/R/app-ui.R
+++ b/R/app-ui.R
@@ -145,7 +145,7 @@ app_ui <- function(request) {
                     )
                   ),
                   "Information",
-                  "Select the manifest file. This file should have one row file to be uploaded to Synapse, including the metadata files, with data about the contents of each file, as well as the study itself. The manifest will be used to upload the data.", # nolint
+                  "Select the manifest file. This file should have one row per file to be uploaded to Synapse, including the metadata files, with data about the contents of each file, as well as the study itself. The manifest will be used to upload the data.", # nolint
                   placement = "top",
                   trigger = "hover"
                 ),

--- a/R/app-ui.R
+++ b/R/app-ui.R
@@ -144,7 +144,7 @@ app_ui <- function(request) {
                     results_boxes_ui("Validation Results")
                   ),
                   tabPanel(
-                    "Data summary",
+                    "Data Summary",
                     fluidRow(
                       shinydashboard::box(
                         title = "Dataset summary",

--- a/R/check-ages-over-90.R
+++ b/R/check-ages-over-90.R
@@ -22,7 +22,7 @@ check_ages_over_90 <- function(data, col = "ageDeath", strict = FALSE,
     return(NULL)
   }
 
-  behavior <- "Ages over 90 should be censored and written as '90+'."
+  behavior <- "Ages over 90 should be censored and written as &#39;90+&#39;."
 
   ## If ageDeath column isn't present, then return check_pass
   if (!any(col %in% names(data))) {

--- a/R/check-parent-syn.R
+++ b/R/check-parent-syn.R
@@ -27,7 +27,7 @@ check_parent_syn <- function(manifest,
       )
     )
   }
-  behavior <- as.character("Synapse IDs should follow the format &#39;syn&#39; followed by digits") # nolint
+  behavior <- "Synapse IDs should follow the format &#39;syn&#39; followed by digits" # nolint
   ## Regex pattern to match "syn" + 1 or more digits
   matches <- grepl("^syn[[:digit:]]+", manifest$parent)
   if (!all(matches)) {

--- a/R/check-parent-syn.R
+++ b/R/check-parent-syn.R
@@ -27,7 +27,7 @@ check_parent_syn <- function(manifest,
       )
     )
   }
-  behavior <- "Synapse IDs should follow the format 'syn' followed by digits"
+  behavior <- as.character("Synapse IDs should follow the format &#39;syn&#39; followed by digits") # nolint
   ## Regex pattern to match "syn" + 1 or more digits
   matches <- grepl("^syn[[:digit:]]+", manifest$parent)
   if (!all(matches)) {

--- a/R/mod-get-study-names.R
+++ b/R/mod-get-study-names.R
@@ -21,14 +21,28 @@ get_study_ui <- function(id) {
 
   tagList(
     # Ability to choose to add to existing study
-    shinyjs::disabled(
-      radioButtons(
-        ns("study_exists"),
-        "Does the study currently exist?",
-        choices = c("Yes", "No"),
-        selected = "Yes"
+    div(
+      class = "result",
+      div(
+        class = "wide",
+        shinyjs::disabled(
+          radioButtons(
+            ns("study_exists"),
+            "Does the study currently exist?",
+            choices = c("Yes", "No"),
+            selected = "Yes"
+          )
+        ),
+      ),
+      popify(
+        tags$a(icon(name = "question-circle"), href = "#"),
+        "Information",
+        "Select your abbreviated study name from the drop-down list. If the name does not appear, select &#39;No&#39; and type in the name.", # nolint
+        placement = "left",
+        trigger = "hover"
       )
     ),
+
     conditionalPanel(
       condition = "input.study_exists == 'Yes'",
       ns = ns,

--- a/R/mod-results-boxes.R
+++ b/R/mod-results-boxes.R
@@ -50,6 +50,7 @@ results_boxes_ui <- function(id) {
       collapsible = TRUE,
       collapsed = TRUE,
       title = textOutput(ns("num_success")),
+      footer = "Your files passed these checks. Well done!",
       status = "success",
       width = 12
     ),
@@ -58,6 +59,7 @@ results_boxes_ui <- function(id) {
       solidHeader = TRUE,
       collapsible = TRUE,
       title = textOutput(ns("num_warn")),
+      footer = "Warnings highlight possible issues in the data, but they may not be applicable to every dataset. If they are not applicable for your data, you can ignore them. For example, if any columns are completely empty they will generate a warning. If you did not collect data for that column, then you can ignore the warning.", # nolint
       status = "warning",
       width = 12
     ),
@@ -66,6 +68,7 @@ results_boxes_ui <- function(id) {
       solidHeader = TRUE,
       collapsible = TRUE,
       title = textOutput(ns("num_fail")),
+      footer = "Any failures in this box must be corrected. A summary of data uploaded can be found in the Data Summary tab, and may help discover the reason behind the failures. Contact the DCC team if you have any questions.", # nolint
       status = "danger",
       width = 12
     )

--- a/R/mod-results-boxes.R
+++ b/R/mod-results-boxes.R
@@ -48,6 +48,7 @@ results_boxes_ui <- function(id) {
       uiOutput(ns("successes")),
       solidHeader = TRUE,
       collapsible = TRUE,
+      collapsed = TRUE,
       title = textOutput(ns("num_success")),
       status = "success",
       width = 12

--- a/R/mod-upload-documentation.R
+++ b/R/mod-upload-documentation.R
@@ -25,34 +25,47 @@ upload_documents_ui <- function(id, study_link_human,
         get_study_ui(ns("doc_study")),
 
         # File import
-        shinyjs::disabled(
-          fileInput(
-            ns("study_doc"),
-            "Upload study description file (.txt, .docx, .md, .pdf, .tex)",
-            accept = c(
-              "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # nolint
-              "application/msword",
-              "application/pdf",
-              "text/plain",
-              "application/x-tex",
-              "text/markdown"
+        popify(
+          shinyjs::disabled(
+            fileInput(
+              ns("study_doc"),
+              "Upload study description file (.txt, .docx, .md, .pdf, .tex)",
+              accept = c(
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # nolint
+                "application/msword",
+                "application/pdf",
+                "text/plain",
+                "application/x-tex",
+                "text/markdown"
+              )
             )
-          )
+          ),
+          "Information",
+          "Select the study description file.",
+          placement = "top",
+          trigger = "hover"
         ),
-        shinyjs::disabled(
-          fileInput(
-            ns("assay_doc"),
-            "Upload assay description files (.txt, .docx, .md, .pdf, .tex)",
-            multiple = TRUE,
-            accept = c(
-              "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # nolint
-              "application/msword",
-              "application/pdf",
-              "text/plain",
-              "application/x-tex",
-              "text/markdown"
+
+        popify(
+          shinyjs::disabled(
+            fileInput(
+              ns("assay_doc"),
+              "Upload assay description files (.txt, .docx, .md, .pdf, .tex)",
+              multiple = TRUE,
+              accept = c(
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # nolint
+                "application/msword",
+                "application/pdf",
+                "text/plain",
+                "application/x-tex",
+                "text/markdown"
+              )
             )
-          )
+          ),
+          "Information",
+          "Select the assay description file(s).",
+          placement = "top",
+          trigger = "hover"
         ),
 
         # Add an indicator feature to submit button

--- a/R/mod-upload-documentation.R
+++ b/R/mod-upload-documentation.R
@@ -25,48 +25,60 @@ upload_documents_ui <- function(id, study_link_human,
         get_study_ui(ns("doc_study")),
 
         # File import
-        popify(
-          tags$a(icon(name = "question-circle"), href = "#"),
-          "Information",
-          "Select the study description file. Please refer to the information on this page to learn what should be in the study description.", # nolint
-          placement = "right",
-          trigger = "hover"
-        ),
-        shinyjs::disabled(
-          fileInput(
-            ns("study_doc"),
-            "Upload study description file (.txt, .docx, .md, .pdf, .tex)",
-            accept = c(
-              "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # nolint
-              "application/msword",
-              "application/pdf",
-              "text/plain",
-              "application/x-tex",
-              "text/markdown"
+        div(
+          class = "result",
+          div(
+            class = "wide",
+            shinyjs::disabled(
+              fileInput(
+                ns("study_doc"),
+                "Upload study description file (.txt, .docx, .md, .pdf, .tex)",
+                accept = c(
+                  "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # nolint
+                  "application/msword",
+                  "application/pdf",
+                  "text/plain",
+                  "application/x-tex",
+                  "text/markdown"
+                )
+              )
             )
+          ),
+          popify(
+            tags$a(icon(name = "question-circle"), href = "#"),
+            "Information",
+            "Select the study description file. Please refer to the information on this page to learn what should be in the study description.", # nolint
+            placement = "left",
+            trigger = "hover"
           )
         ),
 
-        popify(
-          tags$a(icon(name = "question-circle"), href = "#"),
-          "Information",
-          "Select the assay description file(s). Please refer to the information on this page to learn what should be in the assay description.", # nolint
-          placement = "right",
-          trigger = "hover"
-        ),
-        shinyjs::disabled(
-          fileInput(
-            ns("assay_doc"),
-            "Upload assay description files (.txt, .docx, .md, .pdf, .tex)",
-            multiple = TRUE,
-            accept = c(
-              "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # nolint
-              "application/msword",
-              "application/pdf",
-              "text/plain",
-              "application/x-tex",
-              "text/markdown"
+        div(
+          class = "result",
+          div(
+            class = "wide",
+            shinyjs::disabled(
+              fileInput(
+                ns("assay_doc"),
+                "Upload assay description files (.txt, .docx, .md, .pdf, .tex)",
+                multiple = TRUE,
+                accept = c(
+                  "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # nolint
+                  "application/msword",
+                  "application/pdf",
+                  "text/plain",
+                  "application/x-tex",
+                  "text/markdown"
+                )
+              )
             )
+          ),
+          popify(
+            tags$a(icon(name = "question-circle"), href = "#"),
+            "Information",
+            "Select the assay description file(s). Please refer to the information on this page to learn what should be in the assay description.", # nolint
+            placement = "left",
+            trigger = "hover"
           )
         ),
 


### PR DESCRIPTION
Fixes #372, fixes #373

Draft because of the note and questions below. Also probably could have made this two PRs instead of one...

Changes proposed in this pull request:

- Changes behavior of the information tips to appear with hover instead of click
  - Note: need to figure out why some tips will not appear. Noticed this for `check_ages_over_90` and `check_parent_syn`.
- Adds information tips when hovering over file inputs for both documentation and validation sections
  - Questions: Should this tip appear when hovering over the `fileInput` or should I add a question mark bubble for the tip (i.e. is this too obnoxious as it is)? How is the wording for the tips?

Please confirm you've done the following (if applicable):

~~- [ ] Added tests for new functions or for new behavior in existing functions~~
~~- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`~~
~~- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`~~
- [x] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
