### PR TITLE
Clarify wording in columns checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9005
+Version: 0.3.0.9006
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - `check_all()` now checks the biospecimen metadata for ages over 90 in the
   `samplingAge` column
 - Results boxes now contain explanations of their contents
+- The wording of some check results has been updated and, hopefully, clarified
 
 # dccvalidator v0.3.0
 

--- a/R/check-all.R
+++ b/R/check-all.R
@@ -205,7 +205,7 @@ check_all <- function(data, annotations, study, syn) {
     data$file_data[manifest_index][[1]],
     required_cols = config::get("complete_columns")$manifest,
     success_msg = "There is no missing data in columns that are required to be complete in the manifest", # nolint
-    fail_msg = "There is missing data in some columns that are required to be completein the manifest"
+    fail_msg = "There is missing data in some columns that are required to be complete in the manifest"
   )
   complete_cols_indiv <- check_cols_complete(
     data$file_data[indiv_index][[1]],

--- a/R/check-all.R
+++ b/R/check-all.R
@@ -205,7 +205,7 @@ check_all <- function(data, annotations, study, syn) {
     data$file_data[manifest_index][[1]],
     required_cols = config::get("complete_columns")$manifest,
     success_msg = "There is no missing data in columns that are required to be complete in the manifest", # nolint
-    fail_msg = "There is missing data in some columns that are required to be complete in the manifest"
+    fail_msg = "There is missing data in some columns that are required to be complete in the manifest" # nolint
   )
   complete_cols_indiv <- check_cols_complete(
     data$file_data[indiv_index][[1]],

--- a/R/check-all.R
+++ b/R/check-all.R
@@ -179,51 +179,51 @@ check_all <- function(data, annotations, study, syn) {
     data$file_data[manifest_index][[1]],
     required_cols = config::get("complete_columns")$manifest,
     success_msg = "No columns are empty in the manifest",
-    fail_msg = "Some columns are empty in the manifest"
+    fail_msg = "Some columns are completely empty in the manifest"
   )
   empty_cols_indiv <- check_cols_empty(
     data$file_data[indiv_index][[1]],
     required_cols = config::get("complete_columns")$individual,
     success_msg = "No columns are empty in the individual metadata",
-    fail_msg = "Some columns are empty in the individual metadata"
+    fail_msg = "Some columns are completely empty in the individual metadata"
   )
   empty_cols_biosp <- check_cols_empty(
     data$file_data[biosp_index][[1]],
     required_cols = config::get("complete_columns")$biospecimen,
     success_msg = "No columns are empty in the biospecimen metadata",
-    fail_msg = "Some columns are empty in the biospecimen metadata"
+    fail_msg = "Some columns are completely empty in the biospecimen metadata"
   )
   empty_cols_assay <- check_cols_empty(
     data$file_data[assay_index][[1]],
     required_cols = config::get("complete_columns")$assay,
     success_msg = "No columns are empty in the assay metadata",
-    fail_msg = "Some columns are empty in the assay metadata"
+    fail_msg = "Some columns are completely empty in the assay metadata"
   )
 
   # Incomplete required columns produce failures -----------------------------
   complete_cols_manifest <- check_cols_complete(
     data$file_data[manifest_index][[1]],
     required_cols = config::get("complete_columns")$manifest,
-    success_msg = "All required columns present are complete in the manifest", # nolint
-    fail_msg = "Some required columns are incomplete in the manifest"
+    success_msg = "There is no missing data in columns that are required to be complete in the manifest", # nolint
+    fail_msg = "There is missing data in some columns that are required to be completein the manifest"
   )
   complete_cols_indiv <- check_cols_complete(
     data$file_data[indiv_index][[1]],
     required_cols = config::get("complete_columns")$individual,
-    success_msg = "All required columns present are complete in the individual metadata", # nolint
-    fail_msg = "Some required columns are incomplete in the individual metadata" # nolint
+    success_msg = "There is no missing data in columns that are required to be complete in the individual metadata", # nolint
+    fail_msg = "There is missing data in some columns that are required to be complete in the individual metadata" # nolint
   )
   complete_cols_biosp <- check_cols_complete(
     data$file_data[biosp_index][[1]],
     required_cols = config::get("complete_columns")$biospecimen,
-    success_msg = "All required columns present are complete in the biospecimen metadata", # nolint
-    fail_msg = "Some required columns are incomplete in the biospecimen metadata" # nolint
+    success_msg = "There is no missing data in columns that are required to be complete in the biospecimen metadata", # nolint
+    fail_msg = "There is missing data in some columns that are required to be complete in the biospecimen metadata" # nolint
   )
   complete_cols_assay <- check_cols_complete(
     data$file_data[assay_index][[1]],
     required_cols = config::get("complete_columns")$assay,
-    success_msg = "All required columns present are complete in the assay metadata", # nolint
-    fail_msg = "Some required columns are incomplete in the assay metadata" # nolint
+    success_msg = "There is no missing data in columns that are required to be complete in the assay metadata", # nolint
+    fail_msg = "There is missing data in some columns that are required to be complete in the assay metadata" # nolint
   )
 
   # Metadata files appear in manifest ----------------------------------------

--- a/R/check-col-names.R
+++ b/R/check-col-names.R
@@ -68,7 +68,7 @@ check_cols_manifest <- function(data, id,
 #' @rdname check_col_names
 check_cols_individual <- function(data, id,
                                   # nolint start
-                                  success_msg = "All individual metadata columns present",
+                                  success_msg = "All individual metadata column names present",
                                   fail_msg = "Missing columns in the individual metadata file",
                                   # nolint end
                                   ...) {
@@ -77,7 +77,7 @@ check_cols_individual <- function(data, id,
   }
   required <- get_template(id, ...)
   behavior <- glue::glue(
-    "Individual file should contain columns: {glue::glue_collapse(required, sep = ', ')}" # nolint
+    "Individual file should contain columns: {glue::glue_collapse(required, sep = ', ')}. If you do not have data related to a column, the column name should be present and the column should be empty." # nolint
   )
   check_col_names(
     data,
@@ -94,7 +94,7 @@ check_cols_individual <- function(data, id,
 #' @rdname check_col_names
 check_cols_assay <- function(data, id,
                              # nolint start
-                             success_msg = "All assay metadata columns present",
+                             success_msg = "All assay metadata column names present",
                              fail_msg = "Missing columns in the assay metadata file",
                              # nolint end
                              ...) {
@@ -103,7 +103,7 @@ check_cols_assay <- function(data, id,
   }
   required <- get_template(id, ...)
   behavior <- glue::glue(
-    "Assay file should contain columns: {glue::glue_collapse(required, sep = ', ')}" # nolint
+    "Assay file should contain columns: {glue::glue_collapse(required, sep = ', ')}. If you do not have data related to a column, the column name should be present and the column should be empty." # nolint
   )
   check_col_names(
     data,
@@ -120,7 +120,7 @@ check_cols_assay <- function(data, id,
 #' @rdname check_col_names
 check_cols_biospecimen <- function(data, id,
                                    # nolint start
-                                   success_msg = "All biospecimen columns present",
+                                   success_msg = "All biospecimen column names present",
                                    fail_msg = "Missing columns in the biospecimen metadata file",
                                    # nolint end
                                    ...) {
@@ -129,7 +129,7 @@ check_cols_biospecimen <- function(data, id,
   }
   required <- get_template(id, ...)
   behavior <- glue::glue(
-    "Biospecimen file should contain columns: {glue::glue_collapse(required, sep = ', ')}" # nolint
+    "Biospecimen file should contain columns: {glue::glue_collapse(required, sep = ', ')}. If you do not have data related to a column, the column name should be present and the column should be empty." # nolint
   )
   check_col_names(
     data,

--- a/R/check-cols-complete.R
+++ b/R/check-cols-complete.R
@@ -19,8 +19,8 @@
 #' check_cols_complete(dat, c("specimenID", "organ"))
 check_cols_complete <- function(data, required_cols,
                                 empty_values = c(NA, ""), strict = TRUE,
-                                success_msg = "Required columns present are complete", # nolint
-                                fail_msg = "Some required columns are not complete") { # nolint
+                                success_msg = "There is no missing data in columns that are required to be complete", # nolint
+                                fail_msg = "There is missing data in some columns that are required to be complete") { # nolint
   if (is.null(data)) {
     return(NULL)
   }
@@ -33,9 +33,8 @@ check_cols_complete <- function(data, required_cols,
   )
 
   behavior <- paste0(
-    "Columns ",
-    paste(required_cols, collapse = ", "),
-    " should be complete."
+    "There should be no missing values in columns ",
+    paste(required_cols, collapse = ", ")
   )
 
   ## Return success if all required columns have complete data,

--- a/R/check-cols-empty.R
+++ b/R/check-cols-empty.R
@@ -24,7 +24,7 @@
 check_cols_empty <- function(data, empty_values = c(NA, ""),
                              required_cols = NULL, strict = FALSE,
                              success_msg = "No columns are empty",
-                             fail_msg = "Some columns are empty") {
+                             fail_msg = "Some columns are completely empty") {
   if (is.null(data)) {
     return(NULL)
   }

--- a/man/check_col_names.Rd
+++ b/man/check_col_names.Rd
@@ -27,7 +27,7 @@ check_cols_manifest(
 check_cols_individual(
   data,
   id,
-  success_msg = "All individual metadata columns present",
+  success_msg = "All individual metadata column names present",
   fail_msg = "Missing columns in the individual metadata file",
   ...
 )
@@ -35,7 +35,7 @@ check_cols_individual(
 check_cols_assay(
   data,
   id,
-  success_msg = "All assay metadata columns present",
+  success_msg = "All assay metadata column names present",
   fail_msg = "Missing columns in the assay metadata file",
   ...
 )
@@ -43,7 +43,7 @@ check_cols_assay(
 check_cols_biospecimen(
   data,
   id,
-  success_msg = "All biospecimen columns present",
+  success_msg = "All biospecimen column names present",
   fail_msg = "Missing columns in the biospecimen metadata file",
   ...
 )

--- a/man/check_cols_complete.Rd
+++ b/man/check_cols_complete.Rd
@@ -9,8 +9,8 @@ check_cols_complete(
   required_cols,
   empty_values = c(NA, ""),
   strict = TRUE,
-  success_msg = "Required columns present are complete",
-  fail_msg = "Some required columns are not complete"
+  success_msg = "There is no missing data in columns that are required to be complete",
+  fail_msg = "There is missing data in some columns that are required to be complete"
 )
 }
 \arguments{

--- a/man/check_cols_empty.Rd
+++ b/man/check_cols_empty.Rd
@@ -10,7 +10,7 @@ check_cols_empty(
   required_cols = NULL,
   strict = FALSE,
   success_msg = "No columns are empty",
-  fail_msg = "Some columns are empty"
+  fail_msg = "Some columns are completely empty"
 )
 }
 \arguments{


### PR DESCRIPTION
Fixes #376 

Changes proposed in this pull request:

- Clarifies wording in the check results (both the custom messages in `check_all()` and, in some cases, the default wording for the individual functions)

Please confirm you've done the following (if applicable):

- ~[ ] Added tests for new functions or for new behavior in existing functions~
- ~[ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`~
- ~[ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`~
- ~[ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`~
