### PR TITLE
Fix missing word in vignette

### DIFF
--- a/vignettes/customizing-dccvalidator.Rmd
+++ b/vignettes/customizing-dccvalidator.Rmd
@@ -26,7 +26,7 @@ all of the metadata for the study.
 
 For projects like AMP-AD, PsychENCODE, and others that follow the same
 structure, see the next section ("Customizing the Shiny application") for how
-configure an instance of the application for the project.
+to configure an instance of the application for the project.
 
 For projects that do not follow the same structure but wish to use some elements
 of dccvalidator's data validation capabilities, see "Extending dccvalidator"


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixes a missing word in the customizing dccvalidator vignette

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
