### PR TITLE
Update contact email for amp-ad config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -94,6 +94,7 @@ amp-ad:
       - "specimenID"
     assay:
       - "specimenID"
+  contact_email: "AMPAD_SageAdmin@synapse.org"
 
 pec:
   parent: "syn21763123"


### PR DESCRIPTION
Fixes # NA

Changes proposed in this pull request:

- Change config `contact_email` for amp-ad to the AMP-AD Sage Admin team email. I was going to change it to the AMP-AD Sage Curation team, but that team has A LOT of members that don't need to get emails from contributors using dccvalidator.

Please confirm you've done the following (if applicable):

~~- [ ] Added tests for new functions or for new behavior in existing functions~~
~~- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`~~
~~- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`~~
~~- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`~~
