### PR TITLE
Fix GH Actions issue

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -91,17 +91,15 @@ jobs:
           Rscript -e "reticulate::py_install('pandas', pip = TRUE)"
           Rscript -e "reticulate::py_install('synapseclient', pip = TRUE)"
 
-      - name: Setup environment variables
-        if: runner.os != 'Windows'
+      - name: Setup Synapse config file for testing
         run: |
-          echo "SYNAPSE_USER=${{ secrets.SYNAPSE_USERNAME }}" >> $GITHUB_ENV
-          echo "SYNAPSE_APIKEY=${{ secrets.SYNAPSE_API_KEY}}" >> $GITHUB_ENV
-
-      - name: Setup environment variables (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          echo "SYNAPSE_USER=${{ secrets.SYNAPSE_USERNAME }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-          echo "SYNAPSE_APIKEY=${{ secrets.SYNAPSE_API_KEY}}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          OUTPUT_FILE=/tmp/.synapseConfig
+          cat > "$OUTPUT_FILE" << EOM
+          [authentication]
+          username = "${{ secrets.SYNAPSE_USERNAME }}"
+          apikey = "${{ secrets.SYNAPSE_API_KEY}}"
+          EOM
+          chmod +x "$OUTPUT_FILE"
 
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -104,7 +104,8 @@ jobs:
           
       - name: Setup Synapse config file for testing (Windows)
         if: runner.os == 'Windows'
-        run: "[authentication]`nusername = ${{ secrets.SYNAPSE_USERNAME }}`napikey = ${{ secrets.SYNAPSE_API_KEY}}" | Out-File -FilePath "/tmp/.synapseConfig"
+        run: |
+          "authentication]`nusername = ${{ secrets.SYNAPSE_USERNAME }}`napikey = ${{ secrets.SYNAPSE_API_KEY}}" | Out-File -FilePath "tmp/.synapseConfig"
 
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -92,6 +92,7 @@ jobs:
           Rscript -e "reticulate::py_install('synapseclient', pip = TRUE)"
 
       - name: Setup Synapse config file for testing
+        if: runner.os != 'Windows'
         run: |
           OUTPUT_FILE=/tmp/.synapseConfig
           cat > "$OUTPUT_FILE" << EOM
@@ -100,6 +101,10 @@ jobs:
           apikey = "${{ secrets.SYNAPSE_API_KEY}}"
           EOM
           chmod +x "$OUTPUT_FILE"
+          
+      - name: Setup Synapse config file for testing (Windows)
+        if: runner.os == 'Windows'
+        run: "[authentication]`nusername = ${{ secrets.SYNAPSE_USERNAME }}`napikey = ${{ secrets.SYNAPSE_API_KEY}}" | Out-File -FilePath "/tmp/.synapseConfig"
 
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -105,7 +105,7 @@ jobs:
       - name: Setup Synapse config file for testing (Windows)
         if: runner.os == 'Windows'
         run: |
-          "authentication]`nusername = ${{ secrets.SYNAPSE_USERNAME }}`napikey = ${{ secrets.SYNAPSE_API_KEY}}" | Out-File -FilePath "tmp/.synapseConfig"
+          "authentication]`nusername = ${{ secrets.SYNAPSE_USERNAME }}`napikey = ${{ secrets.SYNAPSE_API_KEY}}" | Out-File -FilePath ".synapseConfig"
 
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,8 +29,6 @@ jobs:
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
-      SYNAPSE_USER: ${{ secrets.SYNAPSE_USER }}
-      SYNAPSE_APIKEY: ${{ secrets.SYNAPSE_APIKEY }}
       RETICULATE_AUTOCONFIGURE: 'FALSE'
 
     steps:
@@ -92,6 +90,16 @@ jobs:
           Rscript -e "remotes::install_local()"
           Rscript -e "reticulate::py_install('pandas', pip = TRUE)"
           Rscript -e "reticulate::py_install('synapseclient', pip = TRUE)"
+
+      - name: Setup Synapse config file for testing
+        run: |
+          OUTPUT_FILE=/tmp/.synapseConfig
+          cat > "$OUTPUT_FILE" << EOM
+          [authentication]
+          username = "${{ secrets.SYNAPSE_USERNAME }}"
+          apikey = "${{ secrets.SYNAPSE_API_KEY}}"
+          EOM
+          chmod +x "$OUTPUT_FILE"
 
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -91,15 +91,17 @@ jobs:
           Rscript -e "reticulate::py_install('pandas', pip = TRUE)"
           Rscript -e "reticulate::py_install('synapseclient', pip = TRUE)"
 
-      - name: Setup Synapse config file for testing
+      - name: Setup environment variables
+        if: runner.os != 'Windows'
         run: |
-          OUTPUT_FILE=/tmp/.synapseConfig
-          cat > "$OUTPUT_FILE" << EOM
-          [authentication]
-          username = "${{ secrets.SYNAPSE_USERNAME }}"
-          apikey = "${{ secrets.SYNAPSE_API_KEY}}"
-          EOM
-          chmod +x "$OUTPUT_FILE"
+          echo "SYNAPSE_USER=${{ secrets.SYNAPSE_USERNAME }}" >> $GITHUB_ENV
+          echo "SYNAPSE_APIKEY=${{ secrets.SYNAPSE_API_KEY}}" >> $GITHUB_ENV
+
+      - name: Setup environment variables (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          echo "SYNAPSE_USER=${{ secrets.SYNAPSE_USERNAME }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "SYNAPSE_APIKEY=${{ secrets.SYNAPSE_API_KEY}}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,8 +11,10 @@ on_ci <- function() {
 
 ## Look up env vars and log in to Synapse
 syn_ci_login <- function(syn) {
-  ## Credentials should be written to config file
-  syn$login()
+  ## Credentials are encrypted
+  user   <- Sys.getenv("SYNAPSE_USER")
+  apikey <- Sys.getenv("SYNAPSE_APIKEY")
+  syn$login(email = user, apiKey = apikey)
 }
 
 attempt_instantiate <- function() {

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,12 +9,6 @@ on_ci <- function() {
   # nocov end
 }
 
-## Look up env vars and log in to Synapse
-syn_ci_login <- function(syn) {
-  ## Credentials should be written to config file
-  syn$login()
-}
-
 attempt_instantiate <- function() {
   if (reticulate::py_module_available("synapseclient")) {
     return(synapse$Synapse())
@@ -23,12 +17,12 @@ attempt_instantiate <- function() {
   }
 }
 
-## Attempt to log in using encrypted travis variables if on travis within Sage
-## org, or with regular synLogin() if not on travis. If on travis but not within
-## Sage, do nothing.
+## Attempt to log in using encrypted variables written to .synapseConfig file
+## within Sage org, or with regular synLogin() if not on CI. If on CI but not
+## within Sage, do nothing.
 attempt_login <- function(syn, ...) {
   if (on_ci() & !is.null(syn)) {
-    try(syn_ci_login(syn), silent = TRUE)
+    try(syn$login(), silent = TRUE)
   } else if (reticulate::py_module_available("synapseclient") & !is.null(syn)) {
     syn$login(...)
   } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,10 +11,8 @@ on_ci <- function() {
 
 ## Look up env vars and log in to Synapse
 syn_ci_login <- function(syn) {
-  ## Credentials are encrypted
-  user   <- Sys.getenv("SYNAPSE_USER")
-  apikey <- Sys.getenv("SYNAPSE_APIKEY")
-  syn$login(email = user, apiKey = apikey)
+  ## Credentials should be written to config file
+  syn$login()
 }
 
 attempt_instantiate <- function() {


### PR DESCRIPTION
Fixes #NA

GH Actions seems to be failing when signing into Synapse. This technically should be caught by `skip_if_not(logged_in())`, but doesn't seem to be. 

Changes proposed in this pull request:

- Write login secrets to .synapseConfig file
- Log in via .synapseConfig file instead of environment variables
- Remove helper function that grabbed the environment variables
- Update comment on `attempt_login()`

Please confirm you've done the following (if applicable):

~~- [ ] Added tests for new functions or for new behavior in existing functions~~
~~- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`~~
~~- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`~~
~~- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`~~
