### PR TITLE
Remove shiny file input progress bar

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9009
+Version: 0.3.0.9010
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 - All tooltips now pop-up with hover instead of clicking
 - Add hover tooltips to all fileInputs
 - Fix bug in behavior for `check_ages_over_90()` and `check_parent_syn()`
+- Remove progress bars for file input boxes
 
 # dccvalidator v0.3.0
 

--- a/inst/app/www/custom.css
+++ b/inst/app/www/custom.css
@@ -49,3 +49,7 @@ img {
   background-color: #367FA8;
   padding: 3%;
 }
+
+.shiny-file-input-progress {
+    display: none
+}


### PR DESCRIPTION
Fixes #413, fixes #151

Changes proposed in this pull request:

- Removes fileInput progress bar completely. I'm on the fence about how this looks, as I kind of like the visual feedback of the progress bar, but if it's confusing to people I'm fine with removing it. After this PR is merged we will need to update the version of dccvalidator tracked in the lockfile, since I think it's the installed version whose CSS file gets used when the app is deployed. Relatedly, if you want to test this locally I think you need to run `devtools::install()` before running the app.

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [X] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
