### PR TITLE
Make attempt_login() return NULL if login errors

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,4 @@
-## Check if we are running on travis
+## Check if we are running on CI
 on_ci <- function() {
   if (identical(Sys.getenv("CI"), "true")) {
     return(TRUE)
@@ -22,7 +22,12 @@ attempt_instantiate <- function() {
 ## within Sage, do nothing.
 attempt_login <- function(syn, ...) {
   if (on_ci() & !is.null(syn)) {
-    try(syn$login(), silent = TRUE)
+    attempt <- try(syn$login(), silent = TRUE)
+    if (inherits(attempt, "try-error")) {
+      return(NULL)
+    } else {
+      return(syn)
+    }
   } else if (reticulate::py_module_available("synapseclient") & !is.null(syn)) {
     syn$login(...)
   } else {


### PR DESCRIPTION
Fixes #419

Changes proposed in this pull request:

- Previously `attempt_login()` would return the `try` object if login failed, which is not what we want. This change checks the result of the attempted login and returns `NULL` if it fails. 

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
