### PR TITLE
Add isDocumentation annotation on uploaded files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9010
+Version: 0.3.0.9011
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -245,7 +245,8 @@ app_server <- function(input, output, session) {
             annotations = list(
               study = study_name(),
               metadataType = "individual",
-              species = species_name()
+              species = species_name(),
+              isDocumentation = FALSE
             ),
             synapseclient = synapse,
             syn = syn
@@ -258,7 +259,8 @@ app_server <- function(input, output, session) {
             annotations = list(
               study = study_name(),
               metadataType = "biospecimen",
-              species = species_name()
+              species = species_name(),
+              isDocumentation = FALSE
             ),
             synapseclient = synapse,
             syn = syn
@@ -272,7 +274,8 @@ app_server <- function(input, output, session) {
               study = study_name(),
               metadataType = "assay",
               assay = assay_name(),
-              species = species_name()
+              species = species_name(),
+              isDocumentation = FALSE
             ),
             synapseclient = synapse,
             syn = syn
@@ -284,7 +287,9 @@ app_server <- function(input, output, session) {
             parent = created_folder,
             annotations = list(
               study = study_name(),
-              metadataType = "manifest"
+              metadataType = "manifest",
+              species = species_name(),
+              isDocumentation = FALSE
             ),
             synapseclient = synapse,
             syn = syn

--- a/R/mod-upload-documentation.R
+++ b/R/mod-upload-documentation.R
@@ -150,7 +150,10 @@ upload_documents_server <- function(input, output, session,
     study_names = study_names
   )
   doc_annots <- reactive({
-    list(study = study_name())
+    list(
+      study = study_name(),
+      isDocumentation = TRUE
+    )
   })
 
   # Control inputs by storing in reactiveValues


### PR DESCRIPTION
Fixes #432.

Changes proposed in this pull request:

- Add boolean `isDocumentation` annotation to all uploaded files. Note that this will not add an annotation to previously uploaded data, only new data uploaded.
- Not a part of the PR, but I also updated the fileview schemas for both PEC and AD to include an `isDocumentation` column. Pre-existing files will not have this annotation; If the annotation is needed on these files, please update the existing files to have it.

Please confirm you've done the following (if applicable):

- None applicable. The NEWS section does not need to be updated for this change.
