### PR TITLE
Update pkgdown to install binary

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
           install.packages("remotes")
           remotes::install_deps(dependencies = TRUE)
-          remotes::install_dev("pkgdown")
+          install.packages("pkgdown", type = "binary")
         shell: Rscript {0}
 
       - name: Install package


### PR DESCRIPTION
Fixes #437 

Changes proposed in this pull request:

- Have GH Action install pkgdown via binary

Please confirm you've done the following (if applicable): none relevant
