### PR TITLE
Rename documentation tab

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9012
+Version: 0.3.0.9013
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9014
+Version: 0.3.0.9015
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/R/app-ui.R
+++ b/R/app-ui.R
@@ -20,7 +20,7 @@ app_ui <- function(request) {
         if (!is.na(config::get("path_to_markdown"))) {
           menuItem("Using the App", tabName = "vignette")
         },
-        menuItem("Documentation", tabName = "documentation"),
+        menuItem("Upload Study Documentation", tabName = "documentation"),
         menuItem("Validator", tabName = "validator")
       ),
       create_footer(config::get("contact_email"))


### PR DESCRIPTION
Fixes #365 

Changes proposed in this pull request:

- Changes the "Documentation" tab name to "Upload Study Documentation"

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
