### PR TITLE
Lint, style, and regenerate docs

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -33,8 +33,7 @@ app_server <- function(input, output, session) {
 
   observeEvent(input$cookie, {
     is_logged_in <- FALSE
-    tryCatch(
-      {
+    tryCatch({
         syn$login(sessionToken = input$cookie)
         is_logged_in <- TRUE
       },

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -33,18 +33,21 @@ app_server <- function(input, output, session) {
 
   observeEvent(input$cookie, {
     is_logged_in <- FALSE
-    tryCatch({
-      syn$login(sessionToken = input$cookie)
-      is_logged_in <- TRUE
-    }, error = function(err) {
-      showModal(
-        modalDialog(
-          title = "Login error",
-          HTML("There was an error with the login process. Please refresh your Synapse session by logging out of and back in to <a target=\"_blank\" href=\"https://www.synapse.org/\">Synapse</a>. Then refresh this page to use the application."), # nolint
-          footer = NULL
+    tryCatch(
+      {
+        syn$login(sessionToken = input$cookie)
+        is_logged_in <- TRUE
+      },
+      error = function(err) {
+        showModal(
+          modalDialog(
+            title = "Login error",
+            HTML("There was an error with the login process. Please refresh your Synapse session by logging out of and back in to <a target=\"_blank\" href=\"https://www.synapse.org/\">Synapse</a>. Then refresh this page to use the application."), # nolint
+            footer = NULL
+          )
         )
-      )
-    })
+      }
+    )
     req(is_logged_in)
 
     ## Check if user is in AMP-AD Consortium team (needed in order to create

--- a/R/app-ui.R
+++ b/R/app-ui.R
@@ -202,7 +202,7 @@ app_ui <- function(request) {
                     trigger = "hover"
                   )
                 ),
-                
+
                 # Add an indicator feature to validate button
                 with_busy_indicator_ui(
                   shinyjs::disabled(

--- a/R/app-ui.R
+++ b/R/app-ui.R
@@ -220,7 +220,6 @@ app_ui <- function(request) {
                     "Reset"
                   )
                 )
-
               ),
 
               # Main panel

--- a/R/check-ages-over-90.R
+++ b/R/check-ages-over-90.R
@@ -51,7 +51,6 @@ check_ages_over_90 <- function(data, col = "ageDeath", strict = FALSE,
       type = ifelse(strict, "check_fail", "check_warn")
     )
   }
-
 }
 
 # Does the column (after removing non-numeric characters) contain any values

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -341,7 +341,7 @@ can_coerce <- function(values, class) {
     ## Integers are coercible to numeric
     return(TRUE)
   } else if (class == "integer" && inherits(values, "numeric") &&
-               isTRUE(all.equal(values, as.integer(values)))) {
+    isTRUE(all.equal(values, as.integer(values)))) {
     ## Whole numbers are coercible to integers
     return(TRUE)
   } else if (class == "logical") {

--- a/R/check-schema-df.R
+++ b/R/check-schema-df.R
@@ -10,12 +10,12 @@
 #' @export
 #' @examples
 #' if (requireNamespace("jsonvalidate", quietly = TRUE) &
-#'       requireNamespace("jsonlite", quietly = TRUE)) {
-#' dat <- data.frame(
-#'   x = c(NA, 1, NA),
-#'   y = c(NA, NA, "foo")
-#' )
-#' schema <- '{
+#'   requireNamespace("jsonlite", quietly = TRUE)) {
+#'   dat <- data.frame(
+#'     x = c(NA, 1, NA),
+#'     y = c(NA, NA, "foo")
+#'   )
+#'   schema <- '{
 #'   "$schema": "http://json-schema.org/draft-04/schema#",
 #'   "properties": {
 #'     "x": {

--- a/R/check-schema-json.R
+++ b/R/check-schema-json.R
@@ -9,7 +9,7 @@
 #' @export
 #' @examples
 #' if (requireNamespace("jsonvalidate", quietly = TRUE)) {
-#' schema <- '{
+#'   schema <- '{
 #'   "$schema": "http://json-schema.org/draft-04/schema#",
 #'   "properties": {
 #'     "x": {
@@ -19,14 +19,14 @@
 #'   "required": ["x"]
 #' }
 #' '
-#' json_valid <- '{
+#'   json_valid <- '{
 #'   "x": 3
 #' }'
-#' json_invalid <- '{
+#'   json_invalid <- '{
 #'   "x": 1.5
 #' }'
-#' check_schema_json(json_valid, schema)
-#' check_schema_json(json_invalid, schema)
+#'   check_schema_json(json_valid, schema)
+#'   check_schema_json(json_invalid, schema)
 #' }
 check_schema_json <- function(json, schema,
                               success_msg = "Data is valid against the schema",

--- a/R/df-to-json.R
+++ b/R/df-to-json.R
@@ -10,10 +10,10 @@
 #' @seealso check_schema
 #' @examples
 #' if (requireNamespace("jsonlite", quietly = TRUE)) {
-#' dat <- data.frame(
-#'   x = c(NA, 1L)
-#' )
-#' df_to_json_list(dat)
+#'   dat <- data.frame(
+#'     x = c(NA, 1L)
+#'   )
+#'   df_to_json_list(dat)
 #' }
 df_to_json_list <- function(df) {
   if (!requireNamespace("jsonlite", quietly = TRUE)) {

--- a/R/mod-app-instructions.R
+++ b/R/mod-app-instructions.R
@@ -1,13 +1,14 @@
 get_markdown <- function() {
   HTML(markdown::markdownToHTML(
-    knitr::knit(input = glue::glue(
-      tools::file_path_sans_ext(config::get("path_to_markdown")), ".Rmd"
+    knitr::knit(
+      input = glue::glue(
+        tools::file_path_sans_ext(config::get("path_to_markdown")), ".Rmd"
+      ),
+      output = glue::glue(
+        tools::file_path_sans_ext(config::get("path_to_markdown")), ".md"
+      ),
+      quiet = TRUE
     ),
-    output = glue::glue(
-      tools::file_path_sans_ext(config::get("path_to_markdown")), ".md"
-    ),
-    quiet = TRUE),
     stylesheet = system.file("app/www/custom.css", package = "dccvalidator")
-    )
-    )
+  ))
 }

--- a/R/mod-button-indicator.R
+++ b/R/mod-button-indicator.R
@@ -55,12 +55,11 @@
 #'
 #' ui <- fluidPage(
 #'   includeCSS(
-#'    system.file("app/www/custom.css", package = "dccvalidator")
+#'     system.file("app/www/custom.css", package = "dccvalidator")
 #'   ),
 #'   with_busy_indicator_ui(actionButton("action", label = "Action")),
 #'   fluidRow(column(2, textOutput("value")))
 #' )
-#'
 #' \dontrun{
 #' shinyApp(ui, server)
 #' }

--- a/man/check_col_names.Rd
+++ b/man/check_col_names.Rd
@@ -88,5 +88,5 @@ check_cols_manifest(b, syn)
 }
 }
 \seealso{
-\code{\link[dccvalidator:get_template]{dccvalidator::get_template()}}
+\code{\link[=get_template]{get_template()}}
 }

--- a/man/check_pass.Rd
+++ b/man/check_pass.Rd
@@ -27,7 +27,7 @@ An S3 object of class "check_pass", "check_warn", or "check_fail"
 These functions create custom condition objects with subclasses "check_pass",
 "check_warn", and "check_fail" (inheriting from "message", "warning", or
 "error", respectively). Validation functions such as
-\code{\link[dccvalidator:check_col_names]{dccvalidator::check_col_names()}} use these to report results and provide
+\code{\link[=check_col_names]{check_col_names()}} use these to report results and provide
 additional data on the source of errors or invalid data if needed.
 }
 \examples{

--- a/man/report_unsatisfied_requirements.Rd
+++ b/man/report_unsatisfied_requirements.Rd
@@ -31,7 +31,7 @@ membership <- check_team_membership(
   teams = "3396691",
   user = user,
   syn = syn
- )
+)
 certified <- check_certified_user(user$ownerId, syn = syn)
 report_unsatisfied_requirements(membership, certified, syn = syn)
 }

--- a/tests/testthat/test-metadata-template-dictionary.R
+++ b/tests/testthat/test-metadata-template-dictionary.R
@@ -71,7 +71,7 @@ test_that("verify_dictionary_structure throws error if not a data frame", {
   expect_error(verify_dictionary_structure(dat3))
 })
 
-test_that("verify_dictionary_structure error message is correct if missing columns", { # nolint 
+test_that("verify_dictionary_structure error message is correct if missing columns", { # nolint
   dat <- data.frame(
     key = c("foo", "bar"),
     description = c("foo", "bar"),
@@ -268,7 +268,7 @@ test_that("add_dictionary_sheets returns error if missing columns or annots", {
     annotations = dat[, c("key", "description", "source")]
   ))
   expect_error(add_dictionary_sheets(
-    annotations = data[,  c("value", "valueDescription")]
+    annotations = data[, c("value", "valueDescription")]
   ))
   # NULL/NA won't have a custom error message but should still be checked
   expect_error(add_dictionary_sheets(annotations = NA))


### PR DESCRIPTION
Fixes #439 

Changes proposed in this pull request:

- A few changes to code style to satisfy lintr. I re-ran `styler::style_pkg()` which also introduced some formatting changes. And, I've regenerated the .Rd files that were out of date.

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
