### PR TITLE
Update test for logging in on GH Actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -98,15 +98,15 @@ jobs:
           OUTPUT_FILE=~/.synapseConfig
           cat > "$OUTPUT_FILE" << EOM
           [authentication]
-          username = "${{ secrets.SYNAPSE_USERNAME }}"
-          apikey = "${{ secrets.SYNAPSE_API_KEY}}"
+          username = "${{ secrets.SYNAPSE_USER }}"
+          apikey = "${{ secrets.SYNAPSE_APIKEY}}"
           EOM
           chmod +x "$OUTPUT_FILE"
           
       - name: Setup Synapse config file for testing (Windows)
         if: runner.os == 'Windows'
         run: |
-          "[authentication]`nusername = ${{ secrets.SYNAPSE_USERNAME }}`napikey = ${{ secrets.SYNAPSE_API_KEY}}" | Out-File -FilePath ".synapseConfig"
+          "[authentication]`nusername = ${{ secrets.SYNAPSE_USER }}`napikey = ${{ secrets.SYNAPSE_APIKEY}}" | Out-File -FilePath ".synapseConfig"
 
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Setup Synapse config file for testing
         if: runner.os != 'Windows'
         run: |
-          OUTPUT_FILE=/tmp/.synapseConfig
+          OUTPUT_FILE=~/.synapseConfig
           cat > "$OUTPUT_FILE" << EOM
           [authentication]
           username = "${{ secrets.SYNAPSE_USERNAME }}"
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Synapse config file for testing (Windows)
         if: runner.os == 'Windows'
         run: |
-          "authentication]`nusername = ${{ secrets.SYNAPSE_USERNAME }}`napikey = ${{ secrets.SYNAPSE_API_KEY}}" | Out-File -FilePath ".synapseConfig"
+          "[authentication]`nusername = ${{ secrets.SYNAPSE_USERNAME }}`napikey = ${{ secrets.SYNAPSE_API_KEY}}" | Out-File -FilePath ".synapseConfig"
 
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9013
+Version: 0.3.0.9014
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,4 @@
-## Check if we are running on travis
+## Check if we are running on CI
 on_ci <- function() {
   if (identical(Sys.getenv("CI"), "true")) {
     return(TRUE)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,26 +1,23 @@
 context("utils.R")
 
-syn <- attempt_instantiate()
-attempt_login(syn)
-
-test_that("on_ci() returns TRUE on Travis", {
+test_that("on_ci() returns TRUE on CI", {
   expect_equal(on_ci(), isTRUE(as.logical(Sys.getenv("CI"))))
 })
 
-test_that("login works on travis in main repo", {
+test_that("login works on CI in main repo", {
   ## Lots of other things will fail too if it doesn't, but doesn't hurt to have
   ## a dedicated test
   skip_if_not(on_ci())
 
   ## In this one we do need to ensure it only runs for builds on upstream repo,
-  ## not forks
-  owner <- gsub(
-    "(^[^/]+)(.+)", "\\1",
-    Sys.getenv("TRAVIS_PULL_REQUEST_SLUG")
-  )
+  ## not forks; forks may not have the necessary secrets for the test
+  owner <- Sys.getenv("GITHUB_ACTOR")
   skip_if_not(owner == "Sage-Bionetworks", "Testing on upstream repo")
 
-  login <- try(syn_ci_login(syn), silent = TRUE)
+  syn <- attempt_instantiate()
+  # Check that the client was instantiated or will not get correct error
+  expect_true(inherits(syn, "synapseclient.client.Synapse"))
+  login <- try(attempt_login(syn), silent = TRUE)
   expect_false(inherits(login, "try-error"))
 })
 


### PR DESCRIPTION
Fixes #419. Based on my memory and checking through the references on this, I believe this issue will be resolved.

Changes proposed in this pull request:

- Fix comments and test names referring to Travis, specifically, instead of CI.
- Update github action for R-CMD-Check to write the .synapseConfig file to the home directory, instead of tmp, for all checks except Windows, and add missing bracket to the Windows .synapseConfig.
- Update the test for logging in to work on GH Actions.

Remaining before merge:
- [x] Verify that this fixes the test for logging in while on GH
- [x] Increment version
 
Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
