### PR TITLE
Add 16SrRNAseq template to AD config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -79,6 +79,7 @@ amp-ad:
       methylationArray: "syn22036881"
       MRI: "syn22087332"
       PET: "syn22087299"
+      16SrRNAseq: "syn24184375"
   complete_columns:
     manifest:
       - "consortium"


### PR DESCRIPTION
Fixes # NA

Changes proposed in this pull request:

- Add 16SrRNAseq assay template to AD config

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
