### PR TITLE
Add MODEL-AD assay metadata templates

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -81,6 +81,11 @@ amp-ad:
       PET: "syn22087299"
       16SrRNAseq: "syn24184375"
       metabolomics: "syn24216748"
+      abeta molecular data: "syn22035282"
+      blood chemistry: "syn21819968"
+      proinflammatory molecular data: "syn22035281"
+      immunofluorescence: "syn22035297"
+      
   complete_columns:
     manifest:
       - "consortium"


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:

- Add templates for 4 (previously) MODEL-AD-specific assays


Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
