### PR TITLE
fixes #436

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/lorenzwalthert/pre-commit-hooks
-    rev: v0.0.0.9016
+    rev: v0.1.3
     hooks:
     -   id: style-files
         exclude: 'renv/activate.R'

--- a/tests/testthat/test-check-col-names.R
+++ b/tests/testthat/test-check-col-names.R
@@ -27,7 +27,12 @@ test_that("get_template fails when not logged in to Synapse", {
   skip_if(is.null(syn))
 
   syn$logout()
-  expect_error(get_template("syn12973252", syn))
+  reticulate::py_capture_output(
+    expect_error(
+      get_template("syn12973252", syn)
+    ),
+    type = "stderr"
+  )
 })
 
 attempt_login(syn)
@@ -248,7 +253,12 @@ test_that("check_cols_manifest works for manifest columns", {
 test_that("get_template errors for files that are not xlsx or csv", {
   skip_if_not(logged_in(syn = syn))
 
-  expect_error(get_template("syn17039045", syn = syn))
+  reticulate::py_capture_output(
+    expect_error(
+      get_template("syn17039045", syn = syn)
+    ),
+    type = "stderr"
+  )
 })
 
 test_that("get_template can read in excel and csv templates", {


### PR DESCRIPTION
Fixes #436

Changes proposed in this pull request: captures output from `stderr` so they don't show up during testing.  The behavior of the tests is the same before and after the wrapper function was added.

Things to watch for: versioning in the `pre-commit file` was automatically updated.  I'm not sure that is correct.


Please confirm you've done the following (if applicable):

- [x] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`