### PR TITLE
Remove the extra AMP-AD annotations table from config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -42,9 +42,7 @@ default:
 
 amp-ad:
   parent: "syn21643404"
-  annotations_table:
-    - "syn10242922"
-    - "syn21459391"
+  annotations_table: "syn10242922"
   annotations_link: "https://shinypro.synapse.org/users/kwoo/amp-ad-metadata-dictionary/"
   teams:
     - "3320424"


### PR DESCRIPTION
Fixes # NA

Changes proposed in this pull request:

- Removes the extra AMP-AD metadata dictionary table from the 'amp-ad' config. All metadata values in this table have been moved to the synapseAnnotations repo. With the table being empty, it is unnecessary and will break things if it's not removed.

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
