### PR TITLE
Update check value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - Fix bug in behavior for `check_ages_over_90()` and `check_parent_syn()`
 - Remove progress bars for file input boxes
 - Add script and functions for updating metadata template dictionary sheets.
+- Update to `check_value()`: For keys with enumerated values, parse comma-separated and json-style strings and check all values within against allowed values.
 
 # dccvalidator v0.3.0
 

--- a/R/check-annotation-values.R
+++ b/R/check-annotation-values.R
@@ -28,7 +28,6 @@
 #' dat2 <- data.frame(assay = "rnaSeq")
 #' check_annotation_values(dat1, annots)
 #' check_annotation_values(dat2, annots)
-#'
 #' \dontrun{
 #' syn <- synapse$Synapse()
 #' syn$login()
@@ -253,8 +252,7 @@ check_type <- function(values, key, annotations, whitelist_values = NULL,
     )
   }
 
-  correct_class <- switch(
-    coltype,
+  correct_class <- switch(coltype,
     "STRING" = "character",
     "string" = "character",
     "BOOLEAN" = "logical",
@@ -396,6 +394,13 @@ check_value <- function(values, key, annotations, whitelist_keys = NULL,
   if (all(is.na(annot_values))) {
     return(check_type(values, key, annotations, whitelist_values, return_valid))
   }
+  ## Multiple annotations come through as either comma separated list or
+  ## json-style strings (e.g. "[\"foo\",\"bar\"]"). Separate out the values.
+  if (any(grepl(",", values))) {
+    values <- gsub("\\[|\\]|\"", "", values)
+    values <- unlist(strsplit(values, split = ","))
+    values <- stringr::str_trim(values, side = "both")
+  }
   ## Check values against enumerated values in annotation definitions.
   if (isTRUE(return_valid)) {
     unique(values[values %in% c(annot_values, whitelist) & !is.na(values)])
@@ -435,6 +440,14 @@ check_value <- function(values, key, annotations, whitelist_keys = NULL,
 #' )
 #' dat <- data.frame(
 #'   fileFormat = c("wrong", "txt", "csv", "wrong again"),
+#'   stringsAsFactors = FALSE
+#' )
+#' check_values(dat, annots)
+#'
+#' ## Comma-separated and json-style strings for keys with enumerated values
+#' ## are separated and checked individually
+#' dat <- data.frame(
+#'   fileFormat = c("wrong, txt, csv", "[\"wrong again\",\"csv\"]"),
 #'   stringsAsFactors = FALSE
 #' )
 #' check_values(dat, annots)

--- a/man/check_annotation_values.Rd
+++ b/man/check_annotation_values.Rd
@@ -65,7 +65,6 @@ dat1 <- data.frame(assay = "not a valid assay")
 dat2 <- data.frame(assay = "rnaSeq")
 check_annotation_values(dat1, annots)
 check_annotation_values(dat2, annots)
-
 \dontrun{
 syn <- synapse$Synapse()
 syn$login()

--- a/man/check_values.Rd
+++ b/man/check_values.Rd
@@ -62,4 +62,12 @@ dat <- data.frame(
   stringsAsFactors = FALSE
 )
 check_values(dat, annots)
+
+## Comma-separated and json-style strings for keys with enumerated values
+## are separated and checked individually
+dat <- data.frame(
+  fileFormat = c("wrong, txt, csv", "[\"wrong again\",\"csv\"]"),
+  stringsAsFactors = FALSE
+)
+check_values(dat, annots)
 }

--- a/renv.lock
+++ b/renv.lock
@@ -200,10 +200,15 @@
     },
     "dccvalidator": {
       "Package": "dccvalidator",
-      "Version": "0.3.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "a20a00c4c7750687de0607c56f4d855a"
+      "Version": "0.3.0.9015",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "dccvalidator",
+      "RemoteUsername": "Sage-Bionetworks",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "df58c79db1e02c2dd560516a185f23d43863618a",
+      "Hash": "1c504a6395b1d95e64900108d270a58f"
     },
     "desc": {
       "Package": "desc",
@@ -368,10 +373,10 @@
     },
     "htmltools": {
       "Package": "htmltools",
-      "Version": "0.5.0",
+      "Version": "0.5.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "abf3e9d8a07bf6c669f24df5a7a5658a"
+      "Hash": "daf11a0bf7d3ab70f0d6c6b571aa934d"
     },
     "htmlwidgets": {
       "Package": "htmlwidgets",
@@ -466,10 +471,10 @@
     },
     "magrittr": {
       "Package": "magrittr",
-      "Version": "1.5",
+      "Version": "2.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "c7f13848b0679292077bc7997d930862"
+      "Hash": "491fc94df48397a84854066ad08bcb78"
     },
     "markdown": {
       "Package": "markdown",

--- a/tests/testthat/test-check-annotation-values.R
+++ b/tests/testthat/test-check-annotation-values.R
@@ -158,6 +158,57 @@ test_that("check_value works with a tibble of multiple values", {
   expect_equal(res, character(0))
 })
 
+test_that("check_value checks comma separated or json stringlist enum values", {
+  ## Need to check all values in a comma separated or json stringlist set
+  ## against enumerated annotation values.
+  res1 <- check_value(
+    values = "rnaSeq, rnaSeq, rnaSeq",
+    key = "assay",
+    annotations = annots
+  )
+  res2 <- check_value(
+    values = "[\"rnaSeq\",\"rnaSeq\"]",
+    key = "assay",
+    annotations = annots
+  )
+  res3 <- check_value(
+    values = "foo, rnaSeq, bar, rnaSeq",
+    key = "assay",
+    annotations = annots
+  )
+  res4 <- check_value(
+    values = "[\"bar\",\"rnaSeq\"]",
+    key = "assay",
+    annotations = annots
+  )
+  expect_equal(res1, character(0))
+  expect_equal(res1, character(0))
+  expect_equal(res3, c("foo", "bar"))
+  expect_equal(res4, "bar")
+})
+
+test_that("check_value ignores commas if not enum annotation", {
+  ## Some values are free text and could have commas.
+  ## Check that free text values with commas are ignored if the annotation
+  ## is not enumerated.
+  annotations <- tribble(
+    ~key, ~value, ~columnType,
+    "notes", NA, "STRING"
+  )
+  res1 <- check_value(
+    values = "[\"this is\",\"a weirdly formmated comment\"]",
+    key = "notes",
+    annotations = annotations
+  )
+  res2 <- check_value(
+    values = "In my notes, I use commas",
+    key = "notes",
+    annotations = annotations
+  )
+  expect_equal(res1, character(0))
+  expect_equal(res2, character(0))
+})
+
 ## check_values() --------------------------------------------------------------
 
 test_that("check_values checks multiple values", {


### PR DESCRIPTION
Fixes #207

Note: This update will only work for strings and only if the key has an enumerated set of values (free text values are ignored). If the intent is to have multiple values with a numeric or boolean, it will not check this (e.g. readLength could not have "100, 120, 150"; this would need to be 3 separate rows). Also, that's kind a bit weird so I'm currently fine with ignoring multi-annotation numeric and boolean values unless someone has good use-cases for it.

Changes proposed in this pull request:

- Update `check_value()`. If a key has enumerated values in the annotation set and is a string, then the function will:
  - remove square brackets and extra quotes (needed for json-style string lists)
  - split values that are comma separated
  - trim whitespace around the values
  - check all values found against the annotation set
  - returns only the values that do not match the set
- Added tests.
- Updated a few packages in the renv lock file. If this causes problems with the checks, will revert.
- Updated NEWS.md.

Please confirm you've done the following (if applicable):

- [x] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [x] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
