### PR TITLE
Change default email to Nicole's

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -38,7 +38,7 @@ default:
       - "specimenID"
     assay:
       - "specimenID"
-  contact_email: "karawoo@synapse.org"
+  contact_email: "nicole.kauer@synapse.org"
 
 amp-ad:
   parent: "syn21643404"


### PR DESCRIPTION
Fixes #465

Thanks for catching that, @avanlinden! In the future, it would be great to have an email specific to dccvalidator maintainers, but we do not for the moment. Instead, I'll switch it to my email and it can be updated later, if needed.

Changes proposed in this pull request:

- Change default email in config.yml from Kara's email to mine.

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
