### PR TITLE
Make documentation tab and upload widget optional

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9015
+Version: 0.3.0.9016
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - Fix bug in behavior for `check_ages_over_90()` and `check_parent_syn()`
 - Remove progress bars for file input boxes
 - Add script and functions for updating metadata template dictionary sheets.
+- Add customization options for app's study documentation tab, including necessary updates to config.yml.
 
 # dccvalidator v0.3.0
 

--- a/R/app-config.R
+++ b/R/app-config.R
@@ -1,0 +1,9 @@
+#' Access files in the current app
+#'
+#' @param ... Character vector specifying directory and or file 
+#'        to point to inside the current package.
+#'
+#' @noRd
+app_sys <- function(...) {
+  system.file(..., package = "dccvalidator")
+}

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -92,15 +92,18 @@ app_server <- function(input, output, session) {
       )
       purrr::walk(inputs_to_enable, function(x) shinyjs::enable(x))
 
-      # Documentation server needs created_folder to run correctly
-      callModule(
-        upload_documents_server,
-        "documentation",
-        parent_folder = reactive(created_folder),
-        study_names = all_studies,
-        synapseclient = synapse,
-        syn = syn
-      )
+      if (config::get("docs_tab")$include_tab &
+        config::get("docs_tab")$include_upload_widget) {
+        # Documentation server needs created_folder to run correctly
+        callModule(
+          upload_documents_server,
+          "documentation",
+          parent_folder = reactive(created_folder),
+          study_names = all_studies,
+          synapseclient = synapse,
+          syn = syn
+        )
+      }
     }
 
     ## Reset fileInputs, study name, and other inputs

--- a/R/app-ui.R
+++ b/R/app-ui.R
@@ -20,7 +20,9 @@ app_ui <- function(request) {
           menuItem("Using the App", tabName = "vignette")
         },
         if (config::get("docs_tab")$include_tab) {
-          menuItem("Upload Study Documentation", tabName = "documentation") 
+          menuItem(
+            config::get("docs_tab")$tab_name,
+            tabName = "documentation") 
         },
         menuItem("Validator", tabName = "validator")
       ),
@@ -252,16 +254,15 @@ app_ui <- function(request) {
           if (!is.na(config::get("path_to_markdown"))) {
             tabItem(
               tabName = "vignette",
-              get_markdown()
+              get_markdown(config::get("path_to_markdown"))
             )
           },
           if (config::get("docs_tab")$include_tab) {
             # Documentation tab UI
             upload_documents_ui(
               id = "documentation",
-              study_link_human = config::get("docs_tab")$study_link_human,
-              study_link_animal = config::get("docs_tab")$study_link_animal,
-              study_link_ref = config::get("docs_tab")$study_link_ref
+              markdown_path = config::get("docs_tab")$path_to_docs_markdown,
+              include_widget = config::get("docs_tab")$include_upload_widget
             )
           }
         ),

--- a/R/app-ui.R
+++ b/R/app-ui.R
@@ -255,13 +255,15 @@ app_ui <- function(request) {
               get_markdown()
             )
           },
-          # Documentation tab UI
-          upload_documents_ui(
-            id = "documentation",
-            study_link_human = config::get("study_link_human"),
-            study_link_animal = config::get("study_link_animal"),
-            study_link_ref = config::get("study_link_ref")
-          )
+          if (config::get("docs_tab")$include_tab) {
+            # Documentation tab UI
+            upload_documents_ui(
+              id = "documentation",
+              study_link_human = config::get("docs_tab")$study_link_human,
+              study_link_animal = config::get("docs_tab")$study_link_animal,
+              study_link_ref = config::get("docs_tab")$study_link_ref
+            )
+          }
         ),
         class = "tab-content"
       )

--- a/R/app-ui.R
+++ b/R/app-ui.R
@@ -14,18 +14,18 @@
 app_ui <- function(request) {
   dashboardPage(
     dashboardHeader(title = "Metadata Validation"),
-
     dashboardSidebar(
       sidebarMenu(
         if (!is.na(config::get("path_to_markdown"))) {
           menuItem("Using the App", tabName = "vignette")
         },
-        menuItem("Upload Study Documentation", tabName = "documentation"),
+        if (config::get("docs_tab")$include_tab) {
+          menuItem("Upload Study Documentation", tabName = "documentation") 
+        },
         menuItem("Validator", tabName = "validator")
       ),
       create_footer(config::get("contact_email"))
     ),
-
     dashboardBody(
 
       # Add resources in www

--- a/R/mod-app-instructions.R
+++ b/R/mod-app-instructions.R
@@ -1,3 +1,9 @@
+#' @title Get markdown as HTML
+#'
+#' @description Knit a Rmarkdown file and return it as HTML.
+#'
+#' @noRd
+#' @param markdown_path Path to the markdown file
 get_markdown <- function(markdown_path) {
   HTML(markdown::markdownToHTML(
     knitr::knit(
@@ -9,6 +15,6 @@ get_markdown <- function(markdown_path) {
       ),
       quiet = TRUE
     ),
-    stylesheet = system.file("app/www/custom.css", package = "dccvalidator")
+    stylesheet = app_sys("www/custom.css")
   ))
 }

--- a/R/mod-app-instructions.R
+++ b/R/mod-app-instructions.R
@@ -1,11 +1,11 @@
-get_markdown <- function() {
+get_markdown <- function(markdown_path) {
   HTML(markdown::markdownToHTML(
     knitr::knit(
       input = glue::glue(
-        tools::file_path_sans_ext(config::get("path_to_markdown")), ".Rmd"
+        tools::file_path_sans_ext(markdown_path), ".Rmd"
       ),
       output = glue::glue(
-        tools::file_path_sans_ext(config::get("path_to_markdown")), ".md"
+        tools::file_path_sans_ext(markdown_path), ".md"
       ),
       quiet = TRUE
     ),

--- a/R/mod-upload-documentation.R
+++ b/R/mod-upload-documentation.R
@@ -10,8 +10,10 @@
 #' @noRd
 #' @param id the module id
 #' @param markdown_path path to the markdown file to be displayed
-#' @param include_widget TRUE if the upload widget should be included,
-#'   else FALSE
+#' @param include_widget `TRUE` if the upload widget should be included,
+#'   else `FALSE`. NOTE: if `TRUE`, then the server function
+#'   [`upload_documents_server()`] must be called for the widget to function
+#'   correctly. If `FALSE`, then the server function should not be called.
 #' @return html ui for the module
 upload_documents_ui <- function(id, markdown_path, include_widget) {
   ns <- NS(id)

--- a/R/mod-upload-documentation.R
+++ b/R/mod-upload-documentation.R
@@ -6,20 +6,18 @@
 #'
 #' @noRd
 #' @param id the module id
-#' @param study_link_human html link to example of a study using human data
-#' @param study_link_animal html link to example of a study using animal models
-#' @param study_link_ref html link to example of study acknowledgment
-#'   preference
+#' @param markdown_path path to the markdown file to be displayed
+#' @param include_widget TRUE if the upload widget should be included,
+#'   else FALSE
 #' @return html ui for the module
-upload_documents_ui <- function(id, study_link_human,
-                                study_link_animal, study_link_ref) {
+upload_documents_ui <- function(id, markdown_path, include_widget) {
   ns <- NS(id)
 
   tabItem(
     tabName = id,
     # Use shinyjs
     shinyjs::useShinyjs(),
-    if (config::get("docs_tab")$include_upload_widget) {
+    if (include_widget) {
       sidebarLayout(
         sidebarPanel(
           # UI for getting the study name
@@ -100,20 +98,14 @@ upload_documents_ui <- function(id, study_link_human,
           )
         ),
         mainPanel(
-          upload_docs_instruct_text(
-            study_link_human,
-            study_link_animal,
-            study_link_ref
-          )
+          div(
+            get_markdown(markdown_path = markdown_path)
+          ) 
         )
       )
     } else {
       div(
-        upload_docs_instruct_text(
-          study_link_human,
-          study_link_animal,
-          study_link_ref
-        )
+        get_markdown(markdown_path = markdown_path)
       )
     }
   )

--- a/R/mod-upload-documentation.R
+++ b/R/mod-upload-documentation.R
@@ -19,97 +19,103 @@ upload_documents_ui <- function(id, study_link_human,
     tabName = id,
     # Use shinyjs
     shinyjs::useShinyjs(),
-    sidebarLayout(
-      sidebarPanel(
-        # UI for getting the study name
-        get_study_ui(ns("doc_study")),
+    if (config::get("docs_tab")$include_upload_widget) {
+      sidebarLayout(
+        sidebarPanel(
+          # UI for getting the study name
+          get_study_ui(ns("doc_study")),
 
-        # File import
-        div(
-          class = "result",
+          # File import
           div(
-            class = "wide",
-            shinyjs::disabled(
-              fileInput(
-                ns("study_doc"),
-                "Upload study description file (.txt, .docx, .md, .pdf, .tex)",
-                accept = c(
-                  "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # nolint
-                  "application/msword",
-                  "application/pdf",
-                  "text/plain",
-                  "application/x-tex",
-                  "text/markdown"
+            class = "result",
+            div(
+              class = "wide",
+              shinyjs::disabled(
+                fileInput(
+                  ns("study_doc"),
+                  "Upload study description file (.txt, .docx, .md, .pdf, .tex)",
+                  accept = c(
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # nolint
+                    "application/msword",
+                    "application/pdf",
+                    "text/plain",
+                    "application/x-tex",
+                    "text/markdown"
+                  )
                 )
+              )
+            ),
+            popify(
+              tags$a(icon(name = "question-circle"), href = "#"),
+              "Information",
+              "Select the study description file. Please refer to the information on this page to learn what should be in the study description.", # nolint
+              placement = "left",
+              trigger = "hover"
+            )
+          ),
+          div(
+            class = "result",
+            div(
+              class = "wide",
+              shinyjs::disabled(
+                fileInput(
+                  ns("assay_doc"),
+                  "Upload assay description files (.txt, .docx, .md, .pdf, .tex)",
+                  multiple = TRUE,
+                  accept = c(
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # nolint
+                    "application/msword",
+                    "application/pdf",
+                    "text/plain",
+                    "application/x-tex",
+                    "text/markdown"
+                  )
+                )
+              )
+            ),
+            popify(
+              tags$a(icon(name = "question-circle"), href = "#"),
+              "Information",
+              "Select the assay description file(s). Please refer to the information on this page to learn what should be in the assay description.", # nolint
+              placement = "left",
+              trigger = "hover"
+            )
+          ),
+
+          # Add an indicator feature to submit button
+          with_busy_indicator_ui(
+            shinyjs::disabled(
+              actionButton(
+                ns("upload_docs"),
+                "Submit"
               )
             )
           ),
-          popify(
-            tags$a(icon(name = "question-circle"), href = "#"),
-            "Information",
-            "Select the study description file. Please refer to the information on this page to learn what should be in the study description.", # nolint
-            placement = "left",
-            trigger = "hover"
-          )
-        ),
-
-        div(
-          class = "result",
-          div(
-            class = "wide",
-            shinyjs::disabled(
-              fileInput(
-                ns("assay_doc"),
-                "Upload assay description files (.txt, .docx, .md, .pdf, .tex)",
-                multiple = TRUE,
-                accept = c(
-                  "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # nolint
-                  "application/msword",
-                  "application/pdf",
-                  "text/plain",
-                  "application/x-tex",
-                  "text/markdown"
-                )
-              )
-            )
-          ),
-          popify(
-            tags$a(icon(name = "question-circle"), href = "#"),
-            "Information",
-            "Select the assay description file(s). Please refer to the information on this page to learn what should be in the assay description.", # nolint
-            placement = "left",
-            trigger = "hover"
-          )
-        ),
-
-        # Add an indicator feature to submit button
-        with_busy_indicator_ui(
+          hr(),
           shinyjs::disabled(
             actionButton(
-              ns("upload_docs"),
-              "Submit"
+              ns("reset_btn_doc"),
+              "Reset"
             )
           )
         ),
-
-        hr(),
-
-        shinyjs::disabled(
-          actionButton(
-            ns("reset_btn_doc"),
-            "Reset"
+        mainPanel(
+          upload_docs_instruct_text(
+            study_link_human,
+            study_link_animal,
+            study_link_ref
           )
         )
-      ),
-
-      mainPanel(
+      )
+    } else {
+      div(
         upload_docs_instruct_text(
           study_link_human,
           study_link_animal,
           study_link_ref
         )
       )
-    )
+    }
   )
 }
 
@@ -252,7 +258,6 @@ upload_docs_instruct_text <- function(study_link_human, study_link_animal,
     # nolint start
     overview_text,
     h4("Study Description"),
-
     p("Each study should be given both a descriptive and an abbreviated name. The abbreviation will be used to annotate all content associated with the study. For a study with a human cohort, the study description should include:"),
     tags$ul(
       tags$li(
@@ -268,7 +273,6 @@ upload_docs_instruct_text <- function(study_link_human, study_link_animal,
         "(for post mortem studies) the brain bank name(s) and links to website(s)"
       )
     ),
-
     p("For a study with an animal model cohort, the study description should include:"),
     tags$ul(
       tags$li(
@@ -281,7 +285,6 @@ upload_docs_instruct_text <- function(study_link_human, study_link_animal,
         "(if genetically modified) genotype and genetic background. Provide a link to the strain datasheet(s) if a commercial model, or a description of how it was created if not."
       )
     ),
-
     p("For studies using in-vitro cell culture, the study description should include:"),
     tags$ul(
       tags$li(
@@ -294,11 +297,8 @@ upload_docs_instruct_text <- function(study_link_human, study_link_animal,
         "cell culture information (such as primary or immortalized cell line, passage, treatments, differentiation). If a commercial cell line, provide a link."
       )
     ),
-
     p("Include citations for more study information if available."),
-
     h4("Assay Description"),
-
     p(
       "For each assay, provide a summary of ",
       tags$b("sample processing, data generation,"),

--- a/R/mod-upload-documentation.R
+++ b/R/mod-upload-documentation.R
@@ -1,7 +1,10 @@
 #' Upload documentation to Synapse
 #'
 #' This module creates a page that explains what documentation is needed to
-#' describe the study and assay(s) that make up the study. It allows the user to
+#' describe the study and assay(s) that make up the study. This module is
+#' customizable, both for the displayed documentation (via `markdown_path`) and
+#' for including a sidebar-style widget that allows for documentation upload
+#' (via `include_widget`). The upload widget allows the user to
 #' indicate the name of their study and upload documentation files.
 #'
 #' @noRd
@@ -208,102 +211,4 @@ upload_documents_server <- function(input, output, session,
       reset_inputs("study_doc", "assay_doc")
     })
   })
-}
-
-#' Create instructions for uploading documentation
-#'
-#' This function creates the instruction text for the Documentation
-#' portion of dccvalidator. The study_link_ref argument dictates
-#' whether instructions for uploading an acknowledgment is added.
-#' If study_link_ref is an empty string, then the acknowledgement
-#' instructions are not added.
-#'
-#' @noRd
-#' @inheritParams upload_documents_ui
-#' @return html taglist with instructions
-upload_docs_instruct_text <- function(study_link_human, study_link_animal,
-                                      study_link_ref) {
-  if (study_link_ref != "") {
-    overview_text <- p(
-      # nolint start
-      "This information should be similar to a materials and methods section in a paper. An example of what a study should include can be found ",
-      HTML(glue::glue("<a target =\"_blank\" href=\"{study_link_animal}\">here</a> for an animal model study and ")),
-      HTML(glue::glue("<a target =\"_blank\" href=\"{study_link_human}\">here</a> for a human study.")),
-      "If you wish, also provide an acknowledgement statment and/or reference that should be included in publications resulting from secondary data use; examples can be found ",
-      HTML(glue::glue("<a target =\"_blank\" href=\"{study_link_ref}\">here</a>.")),
-      "This can be provided as part of the study documentation text."
-      # nolint end
-    )
-  } else {
-    overview_text <- p(
-      # nolint start
-      "This information should be similar to a materials and methods section in a paper. An example of what a study should include can be found ",
-      HTML(glue::glue("<a target =\"_blank\" href=\"{study_link_animal}\">here</a> for an animal model study and ")),
-      HTML(glue::glue("<a target =\"_blank\" href=\"{study_link_human}\">here</a> for a human study."))
-      # nolint end
-    )
-  }
-
-  tagList(
-    # Instructions/Description
-    h3("Upload Study Documentation"),
-    # nolint start
-    overview_text,
-    h4("Study Description"),
-    p("Each study should be given both a descriptive and an abbreviated name. The abbreviation will be used to annotate all content associated with the study. For a study with a human cohort, the study description should include:"),
-    tags$ul(
-      tags$li(
-        "study type (randomized controlled study, prospective observational study, case-control study, or post-mortem study)"
-      ),
-      tags$li(
-        "disease focus"
-      ),
-      tags$li(
-        "diagnostic criteria and inclusion/exclusion criteria of study participants"
-      ),
-      tags$li(
-        "(for post mortem studies) the brain bank name(s) and links to website(s)"
-      )
-    ),
-    p("For a study with an animal model cohort, the study description should include:"),
-    tags$ul(
-      tags$li(
-        "species"
-      ),
-      tags$li(
-        "treatments"
-      ),
-      tags$li(
-        "(if genetically modified) genotype and genetic background. Provide a link to the strain datasheet(s) if a commercial model, or a description of how it was created if not."
-      )
-    ),
-    p("For studies using in-vitro cell culture, the study description should include:"),
-    tags$ul(
-      tags$li(
-        "species"
-      ),
-      tags$li(
-        "cell type"
-      ),
-      tags$li(
-        "cell culture information (such as primary or immortalized cell line, passage, treatments, differentiation). If a commercial cell line, provide a link."
-      )
-    ),
-    p("Include citations for more study information if available."),
-    h4("Assay Description"),
-    p(
-      "For each assay, provide a summary of ",
-      tags$b("sample processing, data generation,"),
-      " and ",
-      tags$b("data processing,"),
-      " including which organs and tissues the samples came from. For other tests (such as cognitive assessments or imaging), include a description of how the test was done. Include links for any commercial equipment or tools, code repositories, and citations for more information, if available."
-    ),
-    p(
-      "Detailed protocols are highly recommended. These can be uploaded as pdf together with the data-files, or as links to protocol repositories such as ",
-      tags$a(href = "https://www.protocols.io", "protocols.io", target = "_blank"),
-      (" or "),
-      tags$a(href = "https://theolb.readthedocs.io/en/latest/index.html#", "Open Lab Book.", target = "_blank")
-    )
-    # nolint end
-  )
 }

--- a/config.yml
+++ b/config.yml
@@ -6,9 +6,12 @@ default:
   annotations_table: "syn10242922"
   annotations_link: "https://shinypro.synapse.org/users/nsanati/annotationUI/"
   templates_link: "https://www.synapse.org/#!Synapse:syn18512044"
-  study_link_animal: "https://adknowledgeportal.synapse.org/#/Explore/Studies?Study=syn8391648"
-  study_link_human: "https://adknowledgeportal.synapse.org/#/Explore/Studies?Study=syn3159438"
-  study_link_ref: ""
+  docs_tab:
+    include_tab: TRUE
+    include_upload_widget: TRUE
+    study_link_animal: "https://adknowledgeportal.synapse.org/#/Explore/Studies?Study=syn8391648"
+    study_link_human: "https://adknowledgeportal.synapse.org/#/Explore/Studies?Study=syn3159438"
+    study_link_ref: ""
   teams:
     - "273957"
   templates:
@@ -47,7 +50,12 @@ amp-ad:
   teams:
     - "3320424"
     - "3405451"
-  study_link_ref: "https://adknowledgeportal.synapse.org/#/DataAccess/AcknowledgementStatements"
+  docs_tab:
+    include_tab: TRUE
+    include_upload_widget: FALSE
+    study_link_animal: "https://adknowledgeportal.synapse.org/#/Explore/Studies?Study=syn8391648"
+    study_link_human: "https://adknowledgeportal.synapse.org/#/Explore/Studies?Study=syn3159438"
+    study_link_ref: "https://adknowledgeportal.synapse.org/#/DataAccess/AcknowledgementStatements"
   species_list:
     - "human"
     - "drosophila"
@@ -104,8 +112,11 @@ pec:
   annotations_table: "syn20981788"
   annotations_link: "https://www.synapse.org/#!Synapse:syn20729790"
   templates_link: "https://www.synapse.org/#!Synapse:syn20729790"
-  study_link_animal: "https://www.synapse.org/#!Synapse:syn4566132"
-  study_link_human: "https://www.synapse.org/#!Synapse:syn4590909"
+  docs_tab:
+    include_tab: TRUE
+    include_upload_widget: FALSE
+    study_link_animal: "https://www.synapse.org/#!Synapse:syn4566132"
+    study_link_human: "https://www.synapse.org/#!Synapse:syn4590909"
   teams:
     - "3323356"
   templates:

--- a/config.yml
+++ b/config.yml
@@ -7,11 +7,10 @@ default:
   annotations_link: "https://shinypro.synapse.org/users/nsanati/annotationUI/"
   templates_link: "https://www.synapse.org/#!Synapse:syn18512044"
   docs_tab:
-    include_tab: TRUE
-    include_upload_widget: TRUE
-    study_link_animal: "https://adknowledgeportal.synapse.org/#/Explore/Studies?Study=syn8391648"
-    study_link_human: "https://adknowledgeportal.synapse.org/#/Explore/Studies?Study=syn3159438"
-    study_link_ref: ""
+    include_tab: FALSE
+    include_upload_widget: FALSE
+    tab_name: "Upload Study Documentation"
+    path_to_docs_markdown: "inst/study-documentation-amp-ad.Rmd"
   teams:
     - "273957"
   templates:
@@ -52,10 +51,9 @@ amp-ad:
     - "3405451"
   docs_tab:
     include_tab: TRUE
-    include_upload_widget: FALSE
-    study_link_animal: "https://adknowledgeportal.synapse.org/#/Explore/Studies?Study=syn8391648"
-    study_link_human: "https://adknowledgeportal.synapse.org/#/Explore/Studies?Study=syn3159438"
-    study_link_ref: "https://adknowledgeportal.synapse.org/#/DataAccess/AcknowledgementStatements"
+    include_upload_widget: TRUE
+    tab_name: "Upload Study Documentation"
+    path_to_docs_markdown: "inst/study-documentation-amp-ad.Rmd"
   species_list:
     - "human"
     - "drosophila"
@@ -115,8 +113,8 @@ pec:
   docs_tab:
     include_tab: TRUE
     include_upload_widget: FALSE
-    study_link_animal: "https://www.synapse.org/#!Synapse:syn4566132"
-    study_link_human: "https://www.synapse.org/#!Synapse:syn4590909"
+    tab_name: "Study Documentation"
+    path_to_docs_markdown: "inst/study-documentation-pec.Rmd"
   teams:
     - "3323356"
   templates:

--- a/config.yml
+++ b/config.yml
@@ -7,8 +7,8 @@ default:
   annotations_link: "https://shinypro.synapse.org/users/nsanati/annotationUI/"
   templates_link: "https://www.synapse.org/#!Synapse:syn18512044"
   docs_tab:
-    include_tab: FALSE
-    include_upload_widget: FALSE
+    include_tab: TRUE
+    include_upload_widget: TRUE
     tab_name: "Upload Study Documentation"
     path_to_docs_markdown: "inst/study-documentation-amp-ad.Rmd"
   teams:

--- a/config.yml
+++ b/config.yml
@@ -51,8 +51,8 @@ amp-ad:
     - "3405451"
   docs_tab:
     include_tab: TRUE
-    include_upload_widget: TRUE
-    tab_name: "Upload Study Documentation"
+    include_upload_widget: FALSE
+    tab_name: "Study Documentation"
     path_to_docs_markdown: "inst/study-documentation-amp-ad.Rmd"
   species_list:
     - "human"

--- a/inst/study-documentation-amp-ad.Rmd
+++ b/inst/study-documentation-amp-ad.Rmd
@@ -1,0 +1,47 @@
+---
+title: "AMP-AD Study Documentation"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{amp-ad-study-documentation}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+# Study Documentation
+
+This information should be similar to a materials and methods section in a paper. An example of what a study should include can be found [here](https://adknowledgeportal.synapse.org/#/Explore/Studies?Study=syn8391648) for an animal model study and [here](https://adknowledgeportal.synapse.org/#/Explore/Studies?Study=syn3159438) for a human study. If you wish, also provide an acknowledgement statment and/or reference that should be included in publications resulting from secondary data use; examples can be found [here](https://adknowledgeportal.synapse.org/#/DataAccess/AcknowledgementStatements). This can be provided as part of the study documentation text.
+
+## Study Description
+
+Each study should be given both a descriptive and an abbreviated name. The abbreviation will be used to annotate all content associated with the study. For a study with a human cohort, the study description should include:
+
+- study type (randomized controlled study, prospective observational study, case-control study, or post-mortem study)
+disease focus
+- diagnostic criteria and inclusion/exclusion criteria of study participants
+- (for post mortem studies) the brain bank name(s) and links to website(s)
+
+For a study with an animal model cohort, the study description should include:
+
+- species
+- treatments
+- (if genetically modified) genotype and genetic background. Provide a link to the strain datasheet(s) if a commercial model, or a description of how it was created if not.
+
+For studies using in-vitro cell culture, the study description should include:
+
+- species
+- cell type
+- cell culture information (such as primary or immortalized cell line, passage, treatments, differentiation). If a commercial cell line, provide a link.
+Include citations for more study information if available.
+
+## Assay Description
+
+For each assay, provide a summary of **sample processing**, **data generation**, and **data processing**, including which organs and tissues the samples came from. For other tests (such as cognitive assessments or imaging), include a description of how the test was done. Include links for any commercial equipment or tools, code repositories, and citations for more information, if available.
+
+Detailed protocols are highly recommended. These can be uploaded as pdf together with the data-files, or as links to protocol repositories such as [protocols.io](https://www.protocols.io/) or [Open Lab Book](https://theolb.readthedocs.io/en/latest/index.html#).

--- a/inst/study-documentation-pec.Rmd
+++ b/inst/study-documentation-pec.Rmd
@@ -1,0 +1,47 @@
+---
+title: "PEC Study Documentation"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{pec-study-documentation}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+# Study Documentation
+
+This information should be similar to a materials and methods section in a paper. An example of what a study should include can be found [here](https://www.synapse.org/#!Synapse:syn4566132) for an animal model study and [here](https://www.synapse.org/#!Synapse:syn4590909) for a human study.
+
+## Study Description
+
+Each study should be given both a descriptive and an abbreviated name. The abbreviation will be used to annotate all content associated with the study. For a study with a human cohort, the study description should include:
+
+- study type (randomized controlled study, prospective observational study, case-control study, or post-mortem study)
+disease focus
+- diagnostic criteria and inclusion/exclusion criteria of study participants
+- (for post mortem studies) the brain bank name(s) and links to website(s)
+
+For a study with an animal model cohort, the study description should include:
+
+- species
+- treatments
+- (if genetically modified) genotype and genetic background. Provide a link to the strain datasheet(s) if a commercial model, or a description of how it was created if not.
+
+For studies using in-vitro cell culture, the study description should include:
+
+- species
+- cell type
+- cell culture information (such as primary or immortalized cell line, passage, treatments, differentiation). If a commercial cell line, provide a link.
+Include citations for more study information if available.
+
+## Assay Description
+
+For each assay, provide a summary of **sample processing**, **data generation**, and **data processing**, including which organs and tissues the samples came from. For other tests (such as cognitive assessments or imaging), include a description of how the test was done. Include links for any commercial equipment or tools, code repositories, and citations for more information, if available.
+
+Detailed protocols are highly recommended. These can be uploaded as pdf together with the data-files, or as links to protocol repositories such as [protocols.io](https://www.protocols.io/) or [Open Lab Book](https://theolb.readthedocs.io/en/latest/index.html#).

--- a/inst/study-documentation-pec.Rmd
+++ b/inst/study-documentation-pec.Rmd
@@ -14,34 +14,8 @@ knitr::opts_chunk$set(
 )
 ```
 
-# Study Documentation
+# Submit your Study and Assay Documentation to Synapse
 
-This information should be similar to a materials and methods section in a paper. An example of what a study should include can be found [here](https://www.synapse.org/#!Synapse:syn4566132) for an animal model study and [here](https://www.synapse.org/#!Synapse:syn4590909) for a human study.
+This information should be similar to a materials and methods section in a paper. The description of the study should include the main aims and the study type (e.g.randomized controlled study, prospective observational study, case-control study, or postmortem study). An example of what a study should include can be found [here](https://psychencode.synapse.org/Explore/Studies/DetailsPage?study=syn4566132) for an animal model study and [here](https://psychencode.synapse.org/Explore/Studies/DetailsPage?study=syn4590909) for a human study.
 
-## Study Description
-
-Each study should be given both a descriptive and an abbreviated name. The abbreviation will be used to annotate all content associated with the study. For a study with a human cohort, the study description should include:
-
-- study type (randomized controlled study, prospective observational study, case-control study, or post-mortem study)
-disease focus
-- diagnostic criteria and inclusion/exclusion criteria of study participants
-- (for post mortem studies) the brain bank name(s) and links to website(s)
-
-For a study with an animal model cohort, the study description should include:
-
-- species
-- treatments
-- (if genetically modified) genotype and genetic background. Provide a link to the strain datasheet(s) if a commercial model, or a description of how it was created if not.
-
-For studies using in-vitro cell culture, the study description should include:
-
-- species
-- cell type
-- cell culture information (such as primary or immortalized cell line, passage, treatments, differentiation). If a commercial cell line, provide a link.
-Include citations for more study information if available.
-
-## Assay Description
-
-For each assay, provide a summary of **sample processing**, **data generation**, and **data processing**, including which organs and tissues the samples came from. For other tests (such as cognitive assessments or imaging), include a description of how the test was done. Include links for any commercial equipment or tools, code repositories, and citations for more information, if available.
-
-Detailed protocols are highly recommended. These can be uploaded as pdf together with the data-files, or as links to protocol repositories such as [protocols.io](https://www.protocols.io/) or [Open Lab Book](https://theolb.readthedocs.io/en/latest/index.html#).
+[Follow this link](https://www.synapse.org/#!Synapse:syn25150011) to submit your documentation.

--- a/inst/using-the-dccvalidator-app-amp-ad.Rmd
+++ b/inst/using-the-dccvalidator-app-amp-ad.Rmd
@@ -66,6 +66,7 @@ releasing the data.
 ## Documentation Upload
 
 Each study in AMP-AD has the accompanying [documentation in the portal](https://adknowledgeportal.synapse.org/#/Explore/Studies?Study=syn8391648):
+
 1. **Study Description:** use template located [here](https://www.synapse.org/#!Synapse:syn25014531) to write your study description
 2. **Methods Description(s):** use template located [here](https://www.synapse.org/#!Synapse:syn25018065) to write a methods description for **each** of your assay types
 3. **Acknowledgement statement:** use template located [here](https://www.synapse.org/#!Synapse:syn25014532) to write an acknowledgement statement for the use of those that cite your data

--- a/vignettes/customizing-dccvalidator.Rmd
+++ b/vignettes/customizing-dccvalidator.Rmd
@@ -99,9 +99,14 @@ To install the dccvalidator instead of forking the repository:
 * `annotations_link`: URL to a list or description of allowable annotation
   values (so users can read more)
 * `templates_link`: URL to the location of metadata templates
-* `study_link_animal`: URL to an example study description for an animal model
-  study
-* `study_link_human`: URL to an example study description for a human study
+* `docs_tab`: These settings configure the documentation tab, including the
+  option to not have a tab at all.
+  * `include_tab`: TRUE to include the documentation tab in the app; else FALSE.
+  * `include_upload_widget`: TRUE to include the widget that allows upload of
+    documentation; else FALSE. `include_tab` must be TRUE.
+  * `tab_name`: Desired name of the documentation tab.
+  * `path_to_docs_markdown`: Location of an R Markdown document with
+    documentation instructions.
 * `teams`: The team(s) a user must be a member of in order to use the app. If
   the user is not in any of the teams, they will see a message telling them they
   must be added to one of the teams.

--- a/vignettes/customizing-dccvalidator.Rmd
+++ b/vignettes/customizing-dccvalidator.Rmd
@@ -101,9 +101,9 @@ To install the dccvalidator instead of forking the repository:
 * `templates_link`: URL to the location of metadata templates
 * `docs_tab`: These settings configure the documentation tab, including the
   option to not have a tab at all.
-  * `include_tab`: TRUE to include the documentation tab in the app; else FALSE.
-  * `include_upload_widget`: TRUE to include the widget that allows upload of
-    documentation; else FALSE. `include_tab` must be TRUE.
+  * `include_tab`: `TRUE` to include the documentation tab in the app, else `FALSE`.
+  * `include_upload_widget`: `TRUE` to include the widget that allows upload of
+    documentation, else `FALSE`. `include_tab` must be `TRUE` to have the widget.
   * `tab_name`: Desired name of the documentation tab.
   * `path_to_docs_markdown`: Location of an R Markdown document with
     documentation instructions.

--- a/vignettes/study-documentation-amp-ad.Rmd
+++ b/vignettes/study-documentation-amp-ad.Rmd
@@ -1,0 +1,11 @@
+---
+title: "AMP-AD Study Documentation"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{amp-ad-study-documentation}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r direct-to-child, child = system.file("study-documentation-amp-ad.Rmd", package = "dccvalidator")}
+```

--- a/vignettes/study-documentation-pec.Rmd
+++ b/vignettes/study-documentation-pec.Rmd
@@ -1,0 +1,11 @@
+---
+title: "PEC Study Documentation"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{pec-study-documentation}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r direct-to-child, child = system.file("study-documentation-pec.Rmd", package = "dccvalidator")}
+```


### PR DESCRIPTION
Fixes #460

~~This is a draft PR for now. I need to update documentation and have a couple questions. I have to run out for a moment, but if either of you, @kelshmo and @avanlinden, get a chance to check this out and give me your thoughts, I'd appreciate it! If you need assistance, I can make a test app on the server. I'll also update with some questions for you both when I get a chance.~~

Updating to real PR.

Changes proposed in this pull request:

- Update config.yml to have a section for the documentation tab. In this section, there are options to include the tab and to include the upload widget.
  - `docs_tab$include_tab`: if TRUE, then will include documentation tab in application.
  - `docs_tab$include_upload_widget`: if TRUE, then will include widget in docs tab (must have TRUE in `docs_tab$include_tab`)
  - `docs_tab$tab_name`: Give the desired name of the documentation tab
  - `docs_tab$path_to_docs_markdown`: Path to customized documentation information (as Rmarkdown; similar to app instructions)

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [x] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [x] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
