### PR TITLE
Migrate PEC documentation info to Synapse

### DIFF
--- a/inst/study-documentation-pec.Rmd
+++ b/inst/study-documentation-pec.Rmd
@@ -14,34 +14,8 @@ knitr::opts_chunk$set(
 )
 ```
 
-# Study Documentation
+# Submit your Study and Assay Documentation to Synapse
 
-This information should be similar to a materials and methods section in a paper. An example of what a study should include can be found [here](https://www.synapse.org/#!Synapse:syn4566132) for an animal model study and [here](https://www.synapse.org/#!Synapse:syn4590909) for a human study.
+This information should be similar to a materials and methods section in a paper. The description of the study should include the main aims and the study type (e.g.randomized controlled study, prospective observational study, case-control study, or postmortem study). An example of what a study should include can be found [here](https://psychencode.synapse.org/Explore/Studies/DetailsPage?study=syn4566132) for an animal model study and [here](https://psychencode.synapse.org/Explore/Studies/DetailsPage?study=syn4590909) for a human study.
 
-## Study Description
-
-Each study should be given both a descriptive and an abbreviated name. The abbreviation will be used to annotate all content associated with the study. For a study with a human cohort, the study description should include:
-
-- study type (randomized controlled study, prospective observational study, case-control study, or post-mortem study)
-disease focus
-- diagnostic criteria and inclusion/exclusion criteria of study participants
-- (for post mortem studies) the brain bank name(s) and links to website(s)
-
-For a study with an animal model cohort, the study description should include:
-
-- species
-- treatments
-- (if genetically modified) genotype and genetic background. Provide a link to the strain datasheet(s) if a commercial model, or a description of how it was created if not.
-
-For studies using in-vitro cell culture, the study description should include:
-
-- species
-- cell type
-- cell culture information (such as primary or immortalized cell line, passage, treatments, differentiation). If a commercial cell line, provide a link.
-Include citations for more study information if available.
-
-## Assay Description
-
-For each assay, provide a summary of **sample processing**, **data generation**, and **data processing**, including which organs and tissues the samples came from. For other tests (such as cognitive assessments or imaging), include a description of how the test was done. Include links for any commercial equipment or tools, code repositories, and citations for more information, if available.
-
-Detailed protocols are highly recommended. These can be uploaded as pdf together with the data-files, or as links to protocol repositories such as [protocols.io](https://www.protocols.io/) or [Open Lab Book](https://theolb.readthedocs.io/en/latest/index.html#).
+[Follow this link](https://www.synapse.org/#!Synapse:syn25150011) to submit your documentation.


### PR DESCRIPTION
Changes proposed in this pull request:

- Removes content as it is now tracked in Synapse. 
- Adds a hyperlink to the appropriate Synapse page.