### PR TITLE
add HiC assay template to amp-ad

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -85,6 +85,7 @@ amp-ad:
       PET: "syn22087299"
       16SrRNAseq: "syn24184375"
       metabolomics: "syn24216748"
+      HI-C: "syn25671270"
   complete_columns:
     manifest:
       - "consortium"

--- a/config.yml
+++ b/config.yml
@@ -86,6 +86,7 @@ amp-ad:
       16SrRNAseq: "syn24184375"
       metabolomics: "syn24216748"
       HI-C: "syn25671270"
+      ChIPSeq: "syn22907810"
   complete_columns:
     manifest:
       - "consortium"


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:

- added HiC assay template to the amp-ad section

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
