### PR TITLE
Update template dictionary generation script

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9016
+Version: 0.3.0.9017
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,8 +13,9 @@
 - Fix bug in behavior for `check_ages_over_90()` and `check_parent_syn()`
 - Remove progress bars for file input boxes
 - Add script and functions for updating metadata template dictionary sheets.
-- Update to `check_value()`: For keys with enumerated values, parse comma-separated and json-style strings and check all values within against allowed values.
-- Add customization options for app's study documentation tab, including necessary updates to config.yml.
+- Update to `check_value()`: For keys with enumerated values, parse comma-separated and json-style strings and check all values within against allowed values
+- Add customization options for app's study documentation tab, including necessary updates to config.yml
+- Minor fixes to update-metadata-template-dictionaries.R script
 
 # dccvalidator v0.3.0
 

--- a/inst/scripts/update-metadata-template-dictionaries.R
+++ b/inst/scripts/update-metadata-template-dictionaries.R
@@ -44,6 +44,16 @@ option_list <- list(
 opt_parser <- optparse::OptionParser(option_list = option_list);
 opt <- optparse::parse_args(opt_parser);
 
+## If running within R (not from command line), use opt list below with your
+## needed parameters
+# opt <- list(
+#   config = "amp-ad",
+#   directory = "templates",
+#   username = NA,
+#   password = NA,
+#   apikey = NA
+# )
+
 ## Set the configuration to use
 ## Change "default" to the appropriate configuration
 Sys.setenv(R_CONFIG_ACTIVE = opt$config)
@@ -83,7 +93,7 @@ if (inherits(valid_results, "check_fail")) {
 } # else assume valid structure
 
 ## Get all templates as vector of synIDs
-temps <- get_template_synIDs()
+temps <- unique(get_template_synIDs())
 
 ## Download and update template files with new dictionary sheets
 updated_excel_files <- update_template_dictionaries(
@@ -103,4 +113,10 @@ purrr::walk(
 
 ## Clean up local files
 ## Should be same directory for update_template_dictionaries (default = ".")
-file.remove(list.files(opt$directory, pattern = "^template(.+)\\.xlsx"))
+file.remove(
+  list.files(
+    opt$directory,
+    pattern = "^template(.+)\\.xlsx",
+    full.names = TRUE
+  )
+)


### PR DESCRIPTION
Fixes #NA

Changes proposed in this pull request:

- Only pull unique templates for update. This stops the script from downloading a file twice, with two different names (appends (1)). It also stops it from trying to update a template that it has already updated. Both of these issues can cause errors.
- Add in commented out opt list for simpler line-by-line running in R, instead of from command line.
- Use the whole file path when deleting files. Was not deleting files unless run from the same folder the files were downloaded to.
- Update version and NEWS.md (also removed some periods from previous news lines to stay consistent).

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [x] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
