### PR TITLE
Log in with authToken and add staging endpoints

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9017
+Version: 0.3.0.9018
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",
@@ -72,4 +72,4 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
-SystemRequirements: synapseclient (pypi.org/project/synapseclient)
+SystemRequirements: synapseclient (>= 2.3.1) (pypi.org/project/synapseclient)

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 - Update to `check_value()`: For keys with enumerated values, parse comma-separated and json-style strings and check all values within against allowed values
 - Add customization options for app's study documentation tab, including necessary updates to config.yml
 - Minor fixes to update-metadata-template-dictionaries.R script
+- Update to allow for logging in with authToken
+- Add ability to change to staging endpoints based on config.yml production setting
 
 # dccvalidator v0.3.0
 

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -40,28 +40,28 @@ app_server <- function(input, output, session) {
   observeEvent(input$cookie, {
     is_logged_in <- FALSE
     ## Move log in via sessionToken to a simple try without error handling
-    # try({
-    #     syn$login(sessionToken = input$cookie)
-    #     is_logged_in <- TRUE
-    #   },
-    #   silent = TRUE
-    # )
+    try({
+        syn$login(sessionToken = input$cookie, silent = TRUE)
+        is_logged_in <- TRUE
+      },
+      silent = TRUE
+    )
     ## Use authToken and handle error here if still not logged in
     if (!is_logged_in) {
       tryCatch({
-        syn$login(authToken = input$cookie)
-        is_logged_in <- TRUE
-      },
-      error = function(err) {
-        showModal(
-          modalDialog(
-            title = "Login error",
-            HTML("There was an error with the login process. Please refresh your Synapse session by logging out of and back in to <a target=\"_blank\" href=\"https://www.synapse.org/\">Synapse</a>. Then refresh this page to use the application."), # nolint
-            footer = NULL
+          syn$login(authToken = input$cookie, silent = TRUE)
+          is_logged_in <- TRUE
+        },
+        error = function(err) {
+          showModal(
+            modalDialog(
+              title = "Login error",
+              HTML("There was an error with the login process. Please refresh your Synapse session by logging out of and back in to <a target=\"_blank\" href=\"https://www.synapse.org/\">Synapse</a>. Then refresh this page to use the application."), # nolint
+              footer = NULL
+            )
           )
-        )
-      }
-      ) 
+        }
+      )
     }
     req(is_logged_in)
 

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -15,12 +15,10 @@
 #' }
 app_server <- function(input, output, session) {
   syn <- synapse$Synapse()
-  syn$setEndpoints(
-    authEndpoint = synapse$client$STAGING_ENDPOINTS$authEndpoint,
-    repoEndpoint = synapse$client$STAGING_ENDPOINTS$repoEndpoint,
-    fileHandleEndpoint = synapse$client$STAGING_ENDPOINTS$fileHandleEndpoint,
-    portalEndpoint = synapse$client$STAGING_ENDPOINTS$portalEndpoint
-  )
+
+  if (!config::get("production")) {
+    set_staging_endpoints(syn)
+  }
 
   ## Initial titles for report boxes
   callModule(results_boxes_server, "Validation Results", results = NULL)

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -15,6 +15,12 @@
 #' }
 app_server <- function(input, output, session) {
   syn <- synapse$Synapse()
+  syn$setEndpoints(
+    authEndpoint = synapse$client$STAGING_ENDPOINTS$authEndpoint,
+    repoEndpoint = synapse$client$STAGING_ENDPOINTS$repoEndpoint,
+    fileHandleEndpoint = synapse$client$STAGING_ENDPOINTS$fileHandleEndpoint,
+    portalEndpoint = synapse$client$STAGING_ENDPOINTS$portalEndpoint
+  )
 
   ## Initial titles for report boxes
   callModule(results_boxes_server, "Validation Results", results = NULL)
@@ -33,8 +39,17 @@ app_server <- function(input, output, session) {
 
   observeEvent(input$cookie, {
     is_logged_in <- FALSE
-    tryCatch({
-        syn$login(sessionToken = input$cookie)
+    ## Move log in via sessionToken to a simple try without error handling
+    # try({
+    #     syn$login(sessionToken = input$cookie)
+    #     is_logged_in <- TRUE
+    #   },
+    #   silent = TRUE
+    # )
+    ## Use authToken and handle error here if still not logged in
+    if (!is_logged_in) {
+      tryCatch({
+        syn$login(authToken = input$cookie)
         is_logged_in <- TRUE
       },
       error = function(err) {
@@ -46,7 +61,8 @@ app_server <- function(input, output, session) {
           )
         )
       }
-    )
+      ) 
+    }
     req(is_logged_in)
 
     ## Check if user is in AMP-AD Consortium team (needed in order to create

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,3 +3,12 @@ synapse <- NULL
 .onLoad <- function(libname, pkgname) {
   synapse <<- reticulate::import("synapseclient", delay_load = TRUE)
 }
+
+set_staging_endpoints <- function(syn) {
+  syn$setEndpoints(
+    authEndpoint = synapse$client$STAGING_ENDPOINTS$authEndpoint,
+    repoEndpoint = synapse$client$STAGING_ENDPOINTS$repoEndpoint,
+    fileHandleEndpoint = synapse$client$STAGING_ENDPOINTS$fileHandleEndpoint,
+    portalEndpoint = synapse$client$STAGING_ENDPOINTS$portalEndpoint
+  )
+}

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,5 @@
 default:
+  production: TRUE
   parent: "syn20400157"
   path_to_markdown: "inst/using-the-dccvalidator-app-amp-ad.Rmd"
   study_table: "syn11363298"
@@ -41,6 +42,9 @@ default:
     assay:
       - "specimenID"
   contact_email: "nicole.kauer@synapse.org"
+
+dev:
+  production: FALSE
 
 amp-ad:
   parent: "syn21643404"

--- a/vignettes/customizing-dccvalidator.Rmd
+++ b/vignettes/customizing-dccvalidator.Rmd
@@ -84,6 +84,7 @@ To install the dccvalidator instead of forking the repository:
    
 ### Configuration options
 
+* `production`: `TRUE` to use production Synapse endpoints; `FALSE` to use staging endpoints. Used for testing new versions of the client before they are officially released. See [Synapse client documentation](https://python-docs.synapse.org/build/html/index.html?highlight=endpoints#synapseclient.Synapse.setEndpoints) for information on endpoints.
 * `parent`: The Synapse project or folder where files will be stored
 * `path_to_markdown`: Location of an R Markdown document with app instructions. If you wish to omit instructions, insert `!expr NA`.
 * `study_table`: Synapse ID of a table that lists all of the existing studies in


### PR DESCRIPTION
Fixes # NA

The Synapse cookie is changing this weekend to not include a sessionToken anymore. Instead, this will be an authToken. We will be switching to oauth (#292), but this is a band-aid in the meantime.

**NOTE:** This version requires Synapse client >= 2.3.1. Upgrade your client to test. You may need to upgrade pip, first.
```
pip install --upgrade pip
pip install --upgrade synapseclient
```

Changes proposed in this pull request:

- Try logging in with sessionToken. If doesn't work, log in with authToken.
- Add helper function to change to staging endpoints.
- Add 'production' config param to easily set staging endpoints for testing apps with staged version of Synapse.
- Add 'dev' config that inherits all default config params, but overwrites 'production' to be `FALSE`. Testing the app with staging endpoints would simply mean updating app.R to point to 'dev'.

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [x] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [x] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
