### PR TITLE
add two templates to pec resource

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -140,6 +140,8 @@ pec:
       snpArray: "syn21680759"
       ChIPSeq: "syn21861858"
       bisulfiteSeq: "syn23017098"
+      methylationArray: "syn25805391"
+      immunoassay: "syn25805392"
   species_list:
     - "human"
     - "animal model"


### PR DESCRIPTION
Changes proposed in this pull request:

- Surfaces two templates in PEC app.

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
