### PR TITLE
Remove sessionToken backup and add check for non-anonymous username

### DIFF
--- a/R/app-server.R
+++ b/R/app-server.R
@@ -37,29 +37,31 @@ app_server <- function(input, output, session) {
 
   observeEvent(input$cookie, {
     is_logged_in <- FALSE
-    ## Move log in via sessionToken to a simple try without error handling
-    try({
-        syn$login(sessionToken = input$cookie, silent = TRUE)
-        is_logged_in <- TRUE
-      },
-      silent = TRUE
-    )
     ## Use authToken and handle error here if still not logged in
-    if (!is_logged_in) {
-      tryCatch({
-          syn$login(authToken = input$cookie, silent = TRUE)
-          is_logged_in <- TRUE
-        },
-        error = function(err) {
-          showModal(
-            modalDialog(
-              title = "Login error",
-              HTML("There was an error with the login process. Please refresh your Synapse session by logging out of and back in to <a target=\"_blank\" href=\"https://www.synapse.org/\">Synapse</a>. Then refresh this page to use the application."), # nolint
-              footer = NULL
-            )
-          )
-        }
+    tryCatch({
+      syn$login(authToken = input$cookie, silent = TRUE)
+      is_logged_in <- TRUE
+    },
+    error = function(err) {
+      showModal(
+        modalDialog(
+          title = "Login error",
+          HTML("There was an error with the login process. Please refresh your Synapse session by logging out of and back in to <a target=\"_blank\" href=\"https://www.synapse.org/\">Synapse</a>. Then refresh this page to use the application."), # nolint
+          footer = NULL
+        )
       )
+    }
+    )
+    ## Check that user did not log in as anonymous
+    if (syn$username == "anonymous") {
+      showModal(
+        modalDialog(
+          title = "Login error",
+          HTML("There was an error with the login process. You have been logged in as anonymous."), # nolint
+          footer = NULL
+        )
+      )
+      is_logged_in <- FALSE
     }
     req(is_logged_in)
 


### PR DESCRIPTION
Fixes #NA

Changes proposed in this pull request:

- Remove attempt to log in with sessionToken. This was in place so that the app would function through the weekend. After the Synapse site was pushed, it should have errored and tried using the authToken login. Unfortunately, it's just logging in users as 'anonymous' due to an error in the web client.
- Add a check to make sure user isn't logged in as anonymous. Currently have no reliable fix for this if they are so the modal doesn't give any instructions, just a description of the problem.

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
