### PR TITLE
add AD bisulfiteSeq template

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -91,6 +91,7 @@ amp-ad:
       metabolomics: "syn24216748"
       HI-C: "syn25671270"
       ChIPSeq: "syn22907810"
+      bisulfiteSeq: "syn25830897"
   complete_columns:
     manifest:
       - "consortium"


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:

- add the bisulfite seq assay template to AMP-AD config

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
