### PR TITLE
Update GH Actions to have CI environment variable & minor template update

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,7 @@ Changes proposed in this pull request:
 
 Please confirm you've done the following (if applicable):
 
+- [ ] If adding or altering a configuration value, opened a PR in [dccmonitor](https://github.com/Sage-Bionetworks/dccmonitor) to update the same configuration value or verified that the configuration option is irrelevant in dccmonitor.
 - [ ] Added tests for new functions or for new behavior in existing functions
 - [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
 - [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,6 +30,7 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       RETICULATE_AUTOCONFIGURE: 'FALSE'
+      CI: true
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -7,6 +7,10 @@ name: pkgdown
 jobs:
   pkgdown:
     runs-on: macOS-latest
+
+    env:
+      CI: true
+
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Fixes #472 (hopefully). Since this is small, combining this with the idea of adding in another checkbox for PR templates to encourage configuration updates to happen in dccmonitor, as well.

Changes proposed in this pull request:

- Add environment variable CI = true to the GH Actions.
- Add checkbox to verify that PRs to update configs also include a PR to update dccmonitor config, if needed.

Please confirm you've done the following (if applicable):

- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
