### PR TITLE
Change to cmd prompt for secret output

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -109,7 +109,7 @@ jobs:
           SYNAPSE_USER: ${{ secrets.SYNAPSE_USER }}
           SYNAPSE_APIKEY: ${{ secrets.SYNAPSE_APIKEY}}
         run: |
-          (echo [authentication] & echo username = %SYNAPSE_USER% & echo apikey = %SYNAPSE_APIKEY%) > %~HOME/.synapseConfig
+          (echo [authentication] & echo username = %SYNAPSE_USER% & echo apikey = %SYNAPSE_APIKEY%) > %HOME%\.synapseConfig
 
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -109,7 +109,7 @@ jobs:
           SYNAPSE_USER: ${{ secrets.SYNAPSE_USER }}
           SYNAPSE_APIKEY: ${{ secrets.SYNAPSE_APIKEY}}
         run: |
-          (echo [authentication] & echo username = %SYNAPSE_USER% & echo apikey = %SYNAPSE_APIKEY%) > .synapseConfig
+          (echo [authentication] & echo username = %SYNAPSE_USER% & echo apikey = %SYNAPSE_APIKEY%) > %~HOME/.synapseConfig
 
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -104,8 +104,12 @@ jobs:
           
       - name: Setup Synapse config file for testing (Windows)
         if: runner.os == 'Windows'
+        shell: cmd
+        env:
+          SYNAPSE_USER: ${{ secrets.SYNAPSE_USER }}
+          SYNAPSE_APIKEY: ${{ secrets.SYNAPSE_APIKEY}}
         run: |
-          "[authentication]`nusername = ${{ secrets.SYNAPSE_USER }}`napikey = ${{ secrets.SYNAPSE_APIKEY}}" | Out-File -FilePath "$HOME\.synapseConfig"
+          (echo [authentication] & echo username = %SYNAPSE_USER% & echo apikey = %SYNAPSE_APIKEY%) > .synapseConfig
 
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")


### PR DESCRIPTION
Fixes #492 (hopefully)

Changes proposed in this pull request:

- Use command prompt to generate .synapseConfig

Please confirm you've done the following (if applicable):

- [ ] If adding or altering a configuration value, opened a PR in [dccmonitor](https://github.com/Sage-Bionetworks/dccmonitor) to update the same configuration value or verified that the configuration option is irrelevant in dccmonitor.
- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
