### PR TITLE
Update order and wording for AD biospecimen types in config

### DIFF
--- a/inst/config.yml
+++ b/inst/config.yml
@@ -107,14 +107,14 @@ amp-ad:
       MODEL-AD mouse model: "syn21084071"
     biospecimen_templates:
       human:
+        in vivo, postmortem, other: "syn12973252"
         in vitro: "syn25955510"
-        other (in vivo, postmortem): "syn12973252"
       other mouse or animal model:
+        in vivo, postmortem, other: "syn12973252"
         in vitro: "syn25955510"
-        other (in vivo, postmortem): "syn12973252"
       MODEL-AD mouse model:
+        in vivo, postmortem, other: "syn12973252"
         in vitro: "syn25955510"
-        other (in vivo, postmortem): "syn12973252"
       drosophila: "syn20673251"
     assay_templates:
       ATACseq: "syn22024364"


### PR DESCRIPTION
Fixes #NA

Changes proposed in this pull request:

- Update the wording and order for AD biospecimen types in config

Please confirm you've done the following (if applicable):

- [ ] If adding or altering a configuration value, opened a PR in [dccmonitor](https://github.com/Sage-Bionetworks/dccmonitor) to update the same configuration value or verified that the configuration option is irrelevant in dccmonitor.
- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
