### PR TITLE
Update config ad bio types

### DIFF
--- a/inst/config.yml
+++ b/inst/config.yml
@@ -15,19 +15,15 @@ default:
     path_to_docs_markdown: "inst/study-documentation-amp-ad.Rmd"
   teams:
     - "273957"
-  include_biospecimen_type: TRUE
+  include_biospecimen_type: FALSE
   templates:
     manifest_template: "syn20820080"
     individual_templates:
       human: "syn12973254"
       mouse or other animal model: "syn12973253"
     biospecimen_templates:
-      mouse or other animal model:
-        in vivo, postmortem, other: "syn12973252"
-        in vitro: "syn25955510"
-      human:
-        in vitro: "syn25955510"
-        other (in vivo, postmortem): "syn12973252"
+      mouse or other animal model: "syn12973252"
+      human: "syn12973252"
       drosophila: "syn20673251"
     assay_templates:
       rnaSeq: "sysbio.metadataTemplates-assay.rnaSeq"
@@ -82,7 +78,7 @@ testing:
 
 
 amp-ad:
-  app_url: "https://shinypro.synapse.org/users/kwoo/dccvalidator-app/"
+  app_url: "https://shinypro.synapse.org/users/nkauer/dccvalidator-ad/"
   parent: "syn21643404"
   annotations_table: "syn10242922"
   annotations_link: "https://shinypro.synapse.org/users/kwoo/amp-ad-metadata-dictionary/"

--- a/inst/config.yml
+++ b/inst/config.yml
@@ -107,14 +107,14 @@ amp-ad:
       MODEL-AD mouse model: "syn21084071"
     biospecimen_templates:
       human:
+        in vivo, postmortem, other: "syn12973252"
         in vitro: "syn25955510"
-        other (in vivo, postmortem): "syn12973252"
       other mouse or animal model:
+        in vivo, postmortem, other: "syn12973252"
         in vitro: "syn25955510"
-        other (in vivo, postmortem): "syn12973252"
       MODEL-AD mouse model:
+        in vivo, postmortem, other: "syn12973252"
         in vitro: "syn25955510"
-        other (in vivo, postmortem): "syn12973252"
       drosophila: "syn20673251"
     assay_templates:
       ATACseq: "syn22024364"


### PR DESCRIPTION
Fixes #501 and fixes #502 

Changes proposed in this pull request:

- Update `app_url` for AD version of app to be one I manage
- Remove biospecimen type features for templates from default config

Please confirm you've done the following (if applicable):

- [ ] If adding or altering a configuration value, opened a PR in [dccmonitor](https://github.com/Sage-Bionetworks/dccmonitor) to update the same configuration value or verified that the configuration option is irrelevant in dccmonitor.
- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
