### PR TITLE
Add include_biospecimen_type to PEC config and remove default proteomics

### DIFF
--- a/inst/config.yml
+++ b/inst/config.yml
@@ -27,7 +27,6 @@ default:
       drosophila: "syn20673251"
     assay_templates:
       rnaSeq: "sysbio.metadataTemplates-assay.rnaSeq"
-      proteomics: "syn12973255"
   species_list:
     - "mouse or other animal model"
     - "human"
@@ -164,6 +163,7 @@ pec:
     path_to_docs_markdown: "inst/study-documentation-pec.Rmd"
   teams:
     - "3323356"
+  include_biospecimen_type: TRUE
   templates:
     manifest_template: "syn20782058"
     individual_templates:


### PR DESCRIPTION
Fixes #NA

Changes proposed in this pull request:

- Add `include_biospecimen_type=TRUE` to PEC config
- Remove proteomics assay from default config to stop it from propagating to the other configs

Please confirm you've done the following (if applicable):

- [ ] If adding or altering a configuration value, opened a PR in [dccmonitor](https://github.com/Sage-Bionetworks/dccmonitor) to update the same configuration value or verified that the configuration option is irrelevant in dccmonitor.
- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
