### PR TITLE
Change AD annotations to the AD-specific table

### DIFF
--- a/inst/config.yml
+++ b/inst/config.yml
@@ -79,7 +79,7 @@ testing:
 amp-ad:
   app_url: "https://shinypro.synapse.org/users/nkauer/dccvalidator-ad/"
   parent: "syn21643404"
-  annotations_table: "syn10242922"
+  annotations_table: "syn21459391"
   annotations_link: "https://shinypro.synapse.org/users/kwoo/amp-ad-metadata-dictionary/"
   teams:
     - "3320424"

--- a/tests/testthat/test-metadata-template-dictionary.R
+++ b/tests/testthat/test-metadata-template-dictionary.R
@@ -364,8 +364,8 @@ test_that("get_template_synIDs only returns unique synIDs from config", {
   expected <- c(
     "syn12973254",
     "syn12973253",
-    "syn12973252",
     "syn25955510",
+    "syn12973252",
     "syn20673251",
     "syn12973256",
     "syn20820080"
@@ -385,3 +385,4 @@ test_that("get_template_synIDs does not return JSON schema ids", {
   expected <- c("syn111111", "syn222222")
   expect_equal(get_template_synIDs(dat), expected)
 })
+


### PR DESCRIPTION
Fixes #NA -- I thought I had an issue open for this, but I can't seem to find it.

Changes proposed in this pull request:

- Change the AD annotations table to one that is AD-specific instead of all of synapseAnnotations. This fixes the issue with grants due to PEC requiring specific grants and AD allowing any text.

Please confirm you've done the following (if applicable):

- [ ] If adding or altering a configuration value, opened a PR in [dccmonitor](https://github.com/Sage-Bionetworks/dccmonitor) to update the same configuration value or verified that the configuration option is irrelevant in dccmonitor.
- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
