### PR TITLE
Fix #508

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccvalidator
 Title: Metadata Validation for Data Coordinating Centers
-Version: 0.3.0.9023
+Version: 0.3.0.9024
 Authors@R:
     c(person(given = "Kara",
              family = "Woo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 - `check_all()` now expects the template ids to be included in `data`; if not included, will skip the check for missing column names
 - Added `get_metadataType_indices()` and `gather_template_ids()`
 - Add ability to specify biospecimen templates based on type
+- Fixed logic for resetting biospecimen type UI
 
 # dccvalidator v0.3.0
 

--- a/R/mod-validator.R
+++ b/R/mod-validator.R
@@ -321,20 +321,37 @@ validator_server <- function(input, output, session, study_names, species_list,
       "Species",
       species_list
     )
-    updateRadioButtons(
-      session,
-      "biospecimen_type",
-      "Specimen Type",
-      choiceNames = c("In vitro", "Other (in vivo, postmortem)"),
-      choiceValues = c("in_vitro", "other"),
-      selected = "other"
-    )
     updateSelectInput(
       session,
       "assay_name",
       "Assay type",
       names(assay_templates)
     )
+    specimen_types <- unique(
+      names(
+        get_golem_config("templates")$biospecimen[[input$species]]
+      )
+    )
+    if (!is.null(specimen_types)) {
+      # Grab specimen types from config and default choose first in list
+      updateRadioButtons(
+        session,
+        "biospecimen_type",
+        "Biospecimen Type",
+        choices = specimen_types,
+        selected = specimen_types[1]
+      )
+      shinyjs::show("biospecimen_type")
+    } else {
+      shinyjs::hide("biospecimen_type")
+      updateRadioButtons(
+        session,
+        "biospecimen_type",
+        "Specimen Type",
+        choices = "",
+        selected = ""
+      )
+    }
   })
 
   ## If drosophila species checked, reset fileInput


### PR DESCRIPTION
Reset button wasn't updating the biospecimen type correctly

Fixes #508 

Changes proposed in this pull request:

- Add logic to reset button for updating the biospecimen type

Please confirm you've done the following (if applicable):

- [ ] If adding or altering a configuration value, opened a PR in [dccmonitor](https://github.com/Sage-Bionetworks/dccmonitor) to update the same configuration value or verified that the configuration option is irrelevant in dccmonitor.
- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [x] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
