### PR TITLE
add link to documentation submission form

### DIFF
--- a/inst/study-documentation-amp-ad.Rmd
+++ b/inst/study-documentation-amp-ad.Rmd
@@ -18,6 +18,8 @@ knitr::opts_chunk$set(
 
 This information should be similar to a materials and methods section in a paper. An example of what a study should include can be found [here](https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage?Study=syn8391648){target="_blank"} for an animal model study and [here](https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage?Study=syn3159438){target="_blank"} for a human study. If you wish, also provide an acknowledgement statment and/or reference that should be included in publications resulting from secondary data use; examples can be found in the Acknowledgement sections of the studies linked above. This can be provided as part of the study documentation text.
 
+Documentation should be submitted [here](https://www.synapse.org/#!Synapse:syn25051271) before beginning metadata validation. 
+
 ## Study Description
 
 Each study should be given both a descriptive and an abbreviated name. The abbreviation will be used to annotate all content associated with the study. For a study with a human cohort, the study description should include:


### PR DESCRIPTION
Fixes # (NA)

@RYaxley pointed out that we link to the doc submission Synapse form on the "Using the App" page but not actually on the "Study Documentation" page, which caused some confusion about where to actually submit the documentation. I suggest adding a link specifically to the form on the documentation page within the app, to make it clear that we're not submitting via the app any more. Does this look ok?

-

Please confirm you've done the following (if applicable):

- [ ] If adding or altering a configuration value, opened a PR in [dccmonitor](https://github.com/Sage-Bionetworks/dccmonitor) to update the same configuration value or verified that the configuration option is irrelevant in dccmonitor.
- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
