### PR TITLE
Add ELITE team to AD config

### DIFF
--- a/inst/config.yml
+++ b/inst/config.yml
@@ -84,6 +84,7 @@ amp-ad:
   teams:
     - "3320424"
     - "3405451"
+    - "3433437"
   docs_tab:
     include_tab: TRUE
     include_upload_widget: FALSE


### PR DESCRIPTION
Fixes #NA

Changes proposed in this pull request:

- Add ELITE team to AD teams.

Please confirm you've done the following (if applicable):

- [ ] If adding or altering a configuration value, opened a PR in [dccmonitor](https://github.com/Sage-Bionetworks/dccmonitor) to update the same configuration value or verified that the configuration option is irrelevant in dccmonitor.
- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
