### PR TITLE
Update GH Action to use a Synapse Personal Access Token

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,6 +32,7 @@ jobs:
       RETICULATE_AUTOCONFIGURE: 'FALSE'
       CI: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_PAT }}
 
     steps:
       - uses: actions/checkout@v2
@@ -91,22 +92,6 @@ jobs:
         run: |
           Rscript -e "reticulate::py_discover_config()"
           Rscript -e "reticulate::py_install(c('pandas', 'numpy', 'boto3', 'synapseclient'), pip = TRUE)"
-
-      - name: Setup Synapse config file for testing
-        if: runner.os != 'Windows'
-        run: |
-          OUTPUT_FILE=~/.synapseConfig
-          cat > "$OUTPUT_FILE" << EOM
-          [authentication]
-          username = "${{ secrets.SYNAPSE_USER }}"
-          apikey = "${{ secrets.SYNAPSE_APIKEY }}"
-          EOM
-          chmod +x "$OUTPUT_FILE"
-          
-      - name: Setup Synapse config file for testing (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          "[authentication]`nusername = ${{ secrets.SYNAPSE_USER }}`napikey = ${{ secrets.SYNAPSE_APIKEY }}`n" | Out-File -FilePath "$HOME\.synapseConfig"
 
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")


### PR DESCRIPTION
Fixes # NA

Changes proposed in this pull request:

- Change the action to use a Synapse PAT via environment variable 🤞🏻

Please confirm you've done the following (if applicable):

- [ ] If adding or altering a configuration value, opened a PR in [dccmonitor](https://github.com/Sage-Bionetworks/dccmonitor) to update the same configuration value or verified that the configuration option is irrelevant in dccmonitor.
- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
