### PR TITLE
Change ad team access

### DIFF
--- a/inst/config.yml
+++ b/inst/config.yml
@@ -82,9 +82,7 @@ amp-ad:
   annotations_table: "syn21459391"
   annotations_link: "https://shinypro.synapse.org/users/kwoo/amp-ad-metadata-dictionary/"
   teams:
-    - "3320424"
     - "3405451"
-    - "3433437"
   docs_tab:
     include_tab: TRUE
     include_upload_widget: FALSE

--- a/inst/using-the-dccvalidator-app-amp-ad.Rmd
+++ b/inst/using-the-dccvalidator-app-amp-ad.Rmd
@@ -37,7 +37,7 @@ To use this application you must:
 
 1. Be logged in to Synapse in your browser
 2. Be a [Synapse certified user](https://docs.synapse.org/articles/accounts_certified_users_and_profile_validation.html){target="_blank"}
-3. Be a member of the AMP-AD consortium team
+3. Be a member of the AD_PortalContributor Synapse team
 
 Some portions of the app submit data to Synapse. This allows curators at Sage to
 troubleshoot issues if needed; no one outside the Sage curation team will be


### PR DESCRIPTION

Changes proposed in this pull request:

- remove ELITE_Program and AMP-AD_Consortium teams from the AD app config
- update AD app documentation to refer to the correct team (AD_PortalContributor) for validation access

Please confirm you've done the following (if applicable):

- [x] If adding or altering a configuration value, opened a PR in [dccmonitor](https://github.com/Sage-Bionetworks/dccmonitor) to update the same configuration value or verified that the configuration option is irrelevant in dccmonitor.
- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
