### PR TITLE
change outdated default config values

### DIFF
--- a/inst/config.yml
+++ b/inst/config.yml
@@ -6,7 +6,7 @@ default:
   study_table: "syn11363298"
   samples_table: "syn21578908"
   annotations_table: "syn10242922"
-  annotations_link: "https://shinypro.synapse.org/users/nsanati/annotationUI/"
+  annotations_link: "https://shinypro.synapse.org/users/nkauer/amp-ad-metadata-dictionary/"
   templates_link: "https://www.synapse.org/#!Synapse:syn18512044"
   docs_tab:
     include_tab: TRUE
@@ -43,7 +43,7 @@ default:
       - "specimenID"
     assay:
       - "specimenID"
-  contact_email: "nicole.kauer@synapse.org"
+  contact_email: "AMPAD_SageAdmin@synapse.org"
 
 dev:
   production: FALSE
@@ -82,7 +82,7 @@ amp-ad:
   parent: "syn21643404"
   samples_table: "syn21578908"
   annotations_table: "syn21459391"
-  annotations_link: "https://shinypro.synapse.org/users/kwoo/amp-ad-metadata-dictionary/"
+  annotations_link: "https://shinypro.synapse.org/users/nkauer/amp-ad-metadata-dictionary/"
   teams:
     - "3405451"
   docs_tab:


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:

-

Please confirm you've done the following (if applicable):

- [ ] If adding or altering a configuration value, opened a PR in [dccmonitor](https://github.com/Sage-Bionetworks/dccmonitor) to update the same configuration value or verified that the configuration option is irrelevant in dccmonitor.
- [ ] Added tests for new functions or for new behavior in existing functions
- [ ] If adding a new exported function, added it to the reference section of `_pkgdown.yml`
- [ ] If adding a new configuration option, documented it in `vignettes/customizing_dccvalidator.Rmd`
- [ ] If adding or changing functionality, documented it under "dccvalidator (development version)" in `NEWS.md`
